### PR TITLE
Add support for capturing LoggedMessages

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -33,6 +33,7 @@ library
       Blammo.Logging.LogSettings.LogLevels
       Blammo.Logging.Simple
       Blammo.Logging.Terminal
+      Blammo.Logging.Test
       Data.Aeson.Compat
       Network.Wai.Middleware.Logging
   other-modules:
@@ -54,14 +55,17 @@ library
     , case-insensitive
     , clock
     , containers
+    , dlist
     , envparse
     , exceptions
     , fast-logger
     , http-types
     , lens
     , monad-logger-aeson
+    , mtl
     , text
     , time
+    , unliftio
     , unliftio-core
     , unordered-containers
     , vector
@@ -101,6 +105,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Blammo.Logging.LoggerSpec
       Blammo.Logging.LogSettings.LogLevelsSpec
       Paths_Blammo
   hs-source-dirs:
@@ -115,8 +120,11 @@ test-suite spec
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:
       Blammo
+    , aeson
     , base <5
     , hspec
+    , mtl
+    , text
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)

--- a/README.lhs
+++ b/README.lhs
@@ -263,8 +263,6 @@ warpSettings app = setOnException onEx $ defaultSettings
 ## Integration with Yesod
 
 ```hs
-import Blammo.Logging.Logger (getLoggerLoggerSet)
-
 instance HasLogger App where
   -- ...
 

--- a/package.yaml
+++ b/package.yaml
@@ -46,14 +46,17 @@ library:
     - aeson
     - bytestring
     - containers
+    - dlist
     - envparse
     - exceptions
     - fast-logger
     - lens
     - monad-logger-aeson
+    - mtl
     - text
     - time
     - vector
+    - unliftio
 
     # For the wai Middleware
     - case-insensitive
@@ -71,7 +74,10 @@ tests:
     source-dirs: tests
     dependencies:
       - Blammo
+      - aeson
       - hspec
+      - mtl
+      - text
 
   readme:
     main: README.lhs

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -61,26 +61,23 @@ import Control.Monad.Logger.Aeson
 import Data.Aeson (Series)
 import Data.Aeson.Types (Pair)
 import Data.ByteString (ByteString)
-import System.Log.FastLogger (LoggerSet, flushLogStr, pushLogStrLn)
 
 runLoggerLoggingT :: (MonadIO m, HasLogger env) => env -> LoggingT m a -> m a
 runLoggerLoggingT env f = do
   a <- runLoggingT
     (filterLogger (getLoggerShouldLog logger) f)
-    (loggerOutput loggerSet $ getLoggerReformat logger)
-  a <$ liftIO (flushLogStr loggerSet)
- where
-  logger = env ^. loggerL
-  loggerSet = getLoggerLoggerSet logger
+    (loggerOutput logger $ getLoggerReformat logger)
+  a <$ flushLogStr logger
+  where logger = env ^. loggerL
 
 loggerOutput
-  :: LoggerSet
+  :: Logger
   -> (LogLevel -> ByteString -> ByteString)
   -> Loc
   -> LogSource
   -> LogLevel
   -> LogStr
   -> IO ()
-loggerOutput loggerSet reformat =
+loggerOutput logger reformat =
   defaultOutputWith $ defaultOutputOptions $ \logLevel bytes -> do
-    pushLogStrLn loggerSet $ toLogStr $ reformat logLevel bytes
+    pushLogStrLn logger $ toLogStr $ reformat logLevel bytes

--- a/src/Blammo/Logging/Logger.hs
+++ b/src/Blammo/Logging/Logger.hs
@@ -2,19 +2,36 @@ module Blammo.Logging.Logger
   ( Logger
   , HasLogger(..)
   , newLogger
-  , getLoggerLoggerSet
   , getLoggerReformat
   , getLoggerShouldLog
+  , pushLogStrLn
+  , flushLogStr
+
+  -- * Testing
+  , newTestLogger
+  , LoggedMessage(..)
+  , getLoggedMessages
+  , getLoggedMessagesLenient
+  , getLoggedMessagesUnsafe
+
+  -- * Deprecated
+  , getLoggerLoggerSet
   ) where
 
 import Prelude
 
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Terminal
-import Control.Lens (Lens')
+import Blammo.Logging.Test hiding (getLoggedMessages)
+import qualified Blammo.Logging.Test as LoggedMessages
+import Control.Lens (Lens', view)
+import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Logger.Aeson
+import Control.Monad.Reader (MonadReader)
 import Data.ByteString (ByteString)
+import Data.Either (partitionEithers, rights)
+import Data.List (intercalate)
 import System.IO (stderr, stdout)
 import System.Log.FastLogger
   ( LoggerSet
@@ -23,21 +40,37 @@ import System.Log.FastLogger
   , newStderrLoggerSet
   , newStdoutLoggerSet
   )
+import qualified System.Log.FastLogger as FastLogger (flushLogStr, pushLogStrLn)
+import UnliftIO.Exception (throwString)
 
 data Logger = Logger
   { lLoggerSet :: LoggerSet
   , lReformat :: LogLevel -> ByteString -> ByteString
   , lShouldLog :: LogSource -> LogLevel -> Bool
+  , lLoggedMessages :: Maybe LoggedMessages
   }
 
 getLoggerLoggerSet :: Logger -> LoggerSet
 getLoggerLoggerSet = lLoggerSet
+{-# DEPRECATED getLoggerLoggerSet "Internal function, will be removed in a future version" #-}
 
 getLoggerReformat :: Logger -> LogLevel -> ByteString -> ByteString
 getLoggerReformat = lReformat
 
 getLoggerShouldLog :: Logger -> LogSource -> LogLevel -> Bool
 getLoggerShouldLog = lShouldLog
+
+pushLogStrLn :: MonadIO m => Logger -> LogStr -> m ()
+pushLogStrLn logger str = case lLoggedMessages logger of
+  Nothing -> liftIO $ FastLogger.pushLogStrLn loggerSet str
+  Just lm -> appendLogStr lm str
+  where loggerSet = getLoggerLoggerSet logger
+
+flushLogStr :: MonadIO m => Logger -> m ()
+flushLogStr logger = case lLoggedMessages logger of
+  Nothing -> liftIO $ FastLogger.flushLogStr loggerSet
+  Just _ -> pure ()
+  where loggerSet = getLoggerLoggerSet logger
 
 class HasLogger env where
     loggerL :: Lens' env Logger
@@ -67,5 +100,46 @@ newLogger settings = do
       LogFormatTerminal -> reformatTerminal useColor
 
     lShouldLog = shouldLogLevel settings
+    lLoggedMessages = Nothing
 
   pure $ Logger { .. }
+
+-- | Create a 'Logger' that will capture log messages instead of logging them
+--
+-- See "Blammo.Logging.LoggedMessages" for more details.
+--
+newTestLogger :: MonadIO m => LogSettings -> m Logger
+newTestLogger settings = go <$> newLogger settings <*> newLoggedMessages
+ where
+  go logger loggedMessages =
+    logger { lReformat = const id, lLoggedMessages = Just loggedMessages }
+
+-- | Return the logged messages if 'newTestLogger' was used
+--
+-- If not, the empty list is returned.
+--
+getLoggedMessages
+  :: (MonadIO m, MonadReader env m, HasLogger env)
+  => m [Either String LoggedMessage]
+getLoggedMessages = do
+  logger <- view loggerL
+  maybe (pure []) LoggedMessages.getLoggedMessages $ lLoggedMessages logger
+
+-- | 'getLoggedMessages' but ignore any messages that fail to parse
+getLoggedMessagesLenient
+  :: (MonadIO m, MonadReader env m, HasLogger env) => m [LoggedMessage]
+getLoggedMessagesLenient = rights <$> getLoggedMessages
+
+-- | 'getLoggedMessages' but 'throwString' if any messages failed to parse
+getLoggedMessagesUnsafe
+  :: (MonadIO m, MonadReader env m, HasLogger env) => m [LoggedMessage]
+getLoggedMessagesUnsafe = do
+  (failed, succeeded) <- partitionEithers <$> getLoggedMessages
+
+  succeeded <$ unless
+    (null failed)
+    (throwString
+    $ intercalate "\n"
+    $ "Messages were logged that didn't parse as LoggedMessage:"
+    : failed
+    )

--- a/src/Blammo/Logging/Logger.hs
+++ b/src/Blammo/Logging/Logger.hs
@@ -32,6 +32,7 @@ import Control.Monad.Reader (MonadReader)
 import Data.ByteString (ByteString)
 import Data.Either (partitionEithers, rights)
 import Data.List (intercalate)
+import GHC.Stack (HasCallStack)
 import System.IO (stderr, stdout)
 import System.Log.FastLogger
   ( LoggerSet
@@ -132,7 +133,8 @@ getLoggedMessagesLenient = rights <$> getLoggedMessages
 
 -- | 'getLoggedMessages' but 'throwString' if any messages failed to parse
 getLoggedMessagesUnsafe
-  :: (MonadIO m, MonadReader env m, HasLogger env) => m [LoggedMessage]
+  :: (HasCallStack, MonadIO m, MonadReader env m, HasLogger env)
+  => m [LoggedMessage]
 getLoggedMessagesUnsafe = do
   (failed, succeeded) <- partitionEithers <$> getLoggedMessages
 

--- a/src/Blammo/Logging/Test.hs
+++ b/src/Blammo/Logging/Test.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+
+module Blammo.Logging.Test
+  ( LoggedMessages
+  , LoggedMessage(..)
+  , newLoggedMessages
+  , appendLogStr
+  , getLoggedMessages
+  ) where
+
+import Prelude
+
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Logger.Aeson (LogStr, LoggedMessage(..), fromLogStr)
+import Data.Aeson (eitherDecodeStrict)
+import Data.DList (DList)
+import qualified Data.DList as DList
+import UnliftIO.IORef
+
+newtype LoggedMessages = LoggedMessages
+  { _unLoggedMessages :: IORef (DList LogStr)
+  }
+
+newLoggedMessages :: MonadIO m => m LoggedMessages
+newLoggedMessages = LoggedMessages <$> newIORef DList.empty
+
+appendLogStr :: MonadIO m => LoggedMessages -> LogStr -> m ()
+appendLogStr (LoggedMessages ref) str =
+  atomicModifyIORef' ref $ \x -> (DList.snoc x str, ())
+
+getLoggedMessages :: MonadIO m => LoggedMessages -> m [Either String LoggedMessage]
+getLoggedMessages (LoggedMessages ref) =
+  map (eitherDecodeStrict . fromLogStr) . DList.toList <$> readIORef ref

--- a/tests/Blammo/Logging/LoggerSpec.hs
+++ b/tests/Blammo/Logging/LoggerSpec.hs
@@ -1,0 +1,34 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Blammo.Logging.LoggerSpec
+  ( spec
+  ) where
+
+import Prelude
+
+import Blammo.Logging
+import Blammo.Logging.Logger
+import Control.Monad.Reader (runReaderT)
+import Data.Aeson (Value(..))
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "newTestLogger" $ do
+    it "it captures messages to be accessed later" $ do
+      [Right m1, Right m2] <- do
+        logger <- newTestLogger defaultLogSettings
+        runLoggerLoggingT logger $ flip runReaderT logger $ do
+          logInfo "Hello"
+          logWarn $ "World" :# ["with" .= ("data" :: Text)]
+          getLoggedMessages
+
+      loggedMessageLevel m1 `shouldBe` LevelInfo
+      loggedMessageText m1 `shouldBe` "Hello"
+      loggedMessageMeta m1 `shouldBe` KeyMap.empty
+
+      loggedMessageLevel m2 `shouldBe` LevelWarn
+      loggedMessageText m2 `shouldBe` "World"
+      loggedMessageMeta m2 `shouldBe` KeyMap.fromList [("with", String "data")]

--- a/tests/Blammo/Logging/LoggerSpec.hs
+++ b/tests/Blammo/Logging/LoggerSpec.hs
@@ -10,7 +10,7 @@ import Blammo.Logging
 import Blammo.Logging.Logger
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (Value(..))
-import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Compat as KeyMap
 import Data.Text (Text)
 import Test.Hspec
 


### PR DESCRIPTION
Extends our `Logger` type with an optional `lLoggedMessages` member.
When present (which is only possible through `newTestLogger`), messages
are appended to it rather than actually logged. They can then be fetched
later. This is useful for testing your application's logging behaviors.

The messages are appended as `LogStr`, to both retain performance of the
code under test and defer asserting on the logging behavior until after
execution. When `getLoggedMessages` is called, the `LogStr` values
parsed as JSON into the expected `LoggedMessage` type.

Different `get` functions are available for different use cases, such as
observing failed parses, ignoring them, or failing by exception.
