### PR TITLE
Improve locating client ip in requestLogger 

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.0.2.2
+version:        1.0.2.3
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.0.2.2...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.0.2.3...main)
+
+## [v1.0.2.3](https://github.com/freckle/blammo/compare/v1.0.2.2...v1.0.2.3)
+
+- Fix for localhost `clientIp` value in `requestLogger` ([#18](https://github.com/freckle/blammo/issues/18))
 
 ## [v1.0.2.2](https://github.com/freckle/blammo/compare/v1.0.2.1...v1.0.2.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.0.2.2
+version: 1.0.2.3
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Network/Wai/Middleware/Logging.hs
+++ b/src/Network/Wai/Middleware/Logging.hs
@@ -129,6 +129,13 @@ setConfigGetClientIp x c = c { cGetClientIp = x }
 --
 -- Default is looking up the @x-real-ip@ header.
 --
+-- __NOTE__: Our default uses a somewhat loose definition of /destination/. It
+-- would be more accurate to report the resolved IP address of the @Host@
+-- header, but we don't have that available. Our default of @x-real-ip@ favors
+-- containerized Warp on AWS/ECS, where this value holds the ECS target
+-- container's IP address. This is valuable debugging information and could, if
+-- you squint, be considered a /destination/.
+--
 setConfigGetDestinationIp :: (Request -> Maybe Text) -> Config -> Config
 setConfigGetDestinationIp x c = c { cGetDestinationIp = x }
 


### PR DESCRIPTION
`Wai.remoteHost` is often localhost in proxied contexts. It's fine as a
final fallback, but we should be checking `X-Forwarded-For` or
`X-Real-IP` first. Adding another configuration point and improving the
default addresses this.

Fixes https://github.com/freckle/blammo/issues/18.

There aren't actual specifications for these headers, but they're
present in our AWS deployments and seem to behave as described here:

https://distinctplace.com/2014/04/23/story-behind-x-forwarded-for-and-x-real-ip-headers/

The client's IP address is appended to `X-Forwarded-For` each time a
proxy handles the request. Therefore, the very first value should be the
actual originating client's IP. `X-Real-Ip` _seems_ to be a late
addition to just provide the _final_ value from the forwarded-for again.

Trying these in turn should behave correctly in contexts that have these
headers.