### PR TITLE
Fix LOG_CONCURRENCY parser

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.1.1
+version:        1.1.1.2
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.1.1...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.1.2...main)
+
+## [v1.1.1.2](https://github.com/freckle/blammo/compare/v1.1.1.1...v1.1.1.2)
+
+- Fix bug in `LOG_CONCURRENCY` parser
 
 ## [v1.1.1.1](https://github.com/freckle/blammo/compare/v1.1.1.0...v1.1.1.1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.1.1
+version: 1.1.1.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Blammo/Logging/LogSettings/Env.hs
+++ b/src/Blammo/Logging/LogSettings/Env.hs
@@ -71,7 +71,7 @@ parserWith defaults = ($ defaults) . appEndo . mconcat <$> sequenceA
   , var (endo readLogFormat setLogSettingsFormat) "LOG_FORMAT" (def mempty)
   , var (endo readLogColor setLogSettingsColor) "LOG_COLOR" (def mempty)
   , var (endo readEither setLogSettingsBreakpoint) "LOG_BREAKPOINT" (def mempty)
-  , var (endo readEither setLogSettingsConcurrency) "LOG_CONCURRENCY" (def mempty)
+  , var (endo readEither (setLogSettingsConcurrency . Just)) "LOG_CONCURRENCY" (def mempty)
   ]
 
 endo


### PR DESCRIPTION
This is one of the few settings that is a `Maybe`, so this was
unintentionally using `Read (Maybe Int)`. That meant that,

```
LOG_CONCURRENCY=1
```

Would fail to parse. It actually wanted,

```
LOG_CONCURRENCY="Just 1"
```

Composing `Just` into the setter makes it into `Read Int`, as desired.
