### PR TITLE
Add showLogLevels

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.1.2
+version:        1.1.2.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.1.2...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.0...main)
+
+## [v1.1.2.0](https://github.com/freckle/blammo/compare/v1.1.1.2...v1.1.2.0)
+
+- Add `Blammo.Logging.LogSettings.LogLevels`
 
 ## [v1.1.1.2](https://github.com/freckle/blammo/compare/v1.1.1.1...v1.1.1.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.1.2
+version: 1.1.2.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Blammo/Logging/LogSettings/LogLevels.hs
+++ b/src/Blammo/Logging/LogSettings/LogLevels.hs
@@ -52,6 +52,7 @@ module Blammo.Logging.LogSettings.LogLevels
   , LogLevel(..)
   , newLogLevels
   , readLogLevels
+  , showLogLevels
   , shouldLogLevel
   , defaultLogLevels
   ) where
@@ -103,6 +104,20 @@ readLogLevel t = case T.toLower t of
   "warn" -> LevelWarn
   "error" -> LevelError
   _ -> LevelOther t
+
+showLogLevels :: LogLevels -> String
+showLogLevels LogLevels {..} =
+  unpack $ T.intercalate "," $ showLogLevel llDefaultLevel : map
+    (\(s, l) -> s <> ":" <> showLogLevel l)
+    (Map.toList llSourceLevels)
+
+showLogLevel :: LogLevel -> Text
+showLogLevel = \case
+  LevelDebug -> "debug"
+  LevelInfo -> "info"
+  LevelWarn -> "warn"
+  LevelError -> "error"
+  LevelOther t -> t
 
 shouldLogLevel :: LogLevels -> LogSource -> LogLevel -> Bool
 shouldLogLevel LogLevels {..} source = (`lgte` minLevel)


### PR DESCRIPTION
I have a use-case where I'd like to pass the current App's `LOG_LEVEL`
onto a sub-process that also uses Blammo. Once we've read it into a
`LogLevels`, there was no way to faithfully reproduce it for the child
process without such a function.

We could re-organize things so we retain and pass it through as an
opaque `Text`, but that would be non-trivial in this case. Adding this
function seems reasonable enough and means we won't have to.
