### PR TITLE
Add more convenience functions to Colors module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: freckle/stack-cache-action@v2
-        with:
-          stack-yaml: ${{ matrix.stack-yaml }}
-      - uses: freckle/stack-action@v3
+      - uses: freckle/stack-action@v4
         with:
           stack-yaml: ${{ matrix.stack-yaml }}
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: rwe/actions-hlint-setup@v1
-      - uses: rwe/actions-hlint-run@v2
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/hlint-setup@v2
+      - uses: haskell/actions/hlint-run@v2
         with:
           fail-on: warning
           path: '["src/", "tests/"]'

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Blammo.Logging
       Blammo.Logging.Colors
+      Blammo.Logging.Internal.Logger
       Blammo.Logging.Logger
       Blammo.Logging.LogSettings
       Blammo.Logging.LogSettings.Env

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.2.0
+version:        1.1.2.1
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.1...main)
+
+## [v1.1.2.1](https://github.com/freckle/blammo/compare/v1.1.2.0...v1.1.2.1)
+
+- Add various `getColors*` helper functions
 
 ## [v1.1.2.0](https://github.com/freckle/blammo/compare/v1.1.1.2...v1.1.2.0)
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,4 +1,5 @@
 indentation: 2
+column-limit: 80 # ignored until v12 / ghc-9.6
 function-arrows: leading
 comma-style: leading # default
 import-export-style: leading
@@ -8,6 +9,7 @@ newlines-between-decls: 1 # default
 haddock-style: single-line
 let-style: mixed
 in-style: left-align
+single-constraint-parens: never # ignored until v12 / ghc-9.6
 unicode: never # default
 respectful: true # default
 fixities: [] # default

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.2.0
+version: 1.1.2.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Blammo/Logging/Colors.hs
+++ b/src/Blammo/Logging/Colors.hs
@@ -1,11 +1,30 @@
+-- | Generic facilities for adding terminal escapes to 'Text'
+--
+-- Recommended usage:
+--
+-- @
+-- Colors {..} <- 'getColorsLogger' -- for example
+-- pure $ "This text will be " <> red "red" <> "."
+-- @
 module Blammo.Logging.Colors
   ( Colors (..)
+  , noColors
   , getColors
+  , getColorsLogger
+  , getColorsHandle
+  , getColorsStdout
+  , getColorsStderr
   ) where
 
 import Prelude
 
+import Blammo.Logging.Internal.Logger
+import Blammo.Logging.LogSettings (shouldColorHandle)
+import Control.Lens (to, view)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Reader (MonadReader)
 import Data.Text (Text)
+import System.IO (Handle, stderr, stdout)
 
 data Colors = Colors
   { gray :: Text -> Text
@@ -57,3 +76,36 @@ getColors :: Bool -> Colors
 getColors = \case
   True -> colors
   False -> noColors
+
+-- | Return 'Colors' consistent with whatever your logging is doing
+getColorsLogger :: (MonadReader env m, HasLogger env) => m Colors
+getColorsLogger = view $ loggerL . to (getColors . lShouldColor)
+
+-- | Return 'Colors' consistent with logging, but for 'Handle'
+--
+-- This is useful if you are building text to print to a handle that is not the
+-- one you are logging to.
+--
+-- For example, say you are using,
+--
+-- @
+-- LOG_COLOR=auto
+-- LOG_DESTINATION=@some-file.log
+-- @
+--
+-- That will not log with color, so 'getColorsLogger' will be 'noColor'. If
+-- you're building other text to be printed out, you probably want to respect
+-- that @LOG_COLOR=auto@, so you would use this function instead.
+getColorsHandle
+  :: (MonadIO m, MonadReader env m, HasLogger env) => Handle -> m Colors
+getColorsHandle h = do
+  ls <- view $ loggerL . to lLogSettings
+  getColors <$> shouldColorHandle ls h
+
+-- | Short-cut for @'getColorsHandle' 'stdout'@
+getColorsStdout :: (MonadIO m, MonadReader env m, HasLogger env) => m Colors
+getColorsStdout = getColorsHandle stdout
+
+-- | Short-cut for @'getColorsHandle' 'stderr'@
+getColorsStderr :: (MonadIO m, MonadReader env m, HasLogger env) => m Colors
+getColorsStderr = getColorsHandle stderr

--- a/src/Blammo/Logging/Internal/Logger.hs
+++ b/src/Blammo/Logging/Internal/Logger.hs
@@ -1,0 +1,28 @@
+module Blammo.Logging.Internal.Logger
+  ( Logger (..)
+  , HasLogger (..)
+  ) where
+
+import Prelude
+
+import Blammo.Logging.LogSettings
+import Blammo.Logging.Test hiding (getLoggedMessages)
+import Control.Lens (Lens')
+import Control.Monad.Logger.Aeson
+import Data.ByteString (ByteString)
+import System.Log.FastLogger (LoggerSet)
+
+data Logger = Logger
+  { lLogSettings :: LogSettings
+  , lLoggerSet :: LoggerSet
+  , lReformat :: LogLevel -> ByteString -> ByteString
+  , lShouldLog :: LogSource -> LogLevel -> Bool
+  , lShouldColor :: Bool
+  , lLoggedMessages :: Maybe LoggedMessages
+  }
+
+class HasLogger env where
+  loggerL :: Lens' env Logger
+
+instance HasLogger Logger where
+  loggerL = id

--- a/src/Blammo/Logging/Logger.hs
+++ b/src/Blammo/Logging/Logger.hs
@@ -22,11 +22,12 @@ module Blammo.Logging.Logger
 
 import Prelude
 
+import Blammo.Logging.Internal.Logger
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Terminal
 import Blammo.Logging.Test hiding (getLoggedMessages)
 import qualified Blammo.Logging.Test as LoggedMessages
-import Control.Lens (Lens', view)
+import Control.Lens (view)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Logger.Aeson
@@ -49,15 +50,6 @@ import System.Log.FastLogger.Compat
   , newStdoutLoggerSetN
   )
 import UnliftIO.Exception (throwString)
-
-data Logger = Logger
-  { lLogSettings :: LogSettings
-  , lLoggerSet :: LoggerSet
-  , lReformat :: LogLevel -> ByteString -> ByteString
-  , lShouldLog :: LogSource -> LogLevel -> Bool
-  , lShouldColor :: Bool
-  , lLoggedMessages :: Maybe LoggedMessages
-  }
 
 getLoggerLogSettings :: Logger -> LogSettings
 getLoggerLogSettings = lLogSettings
@@ -94,12 +86,6 @@ flushLogStr logger = case lLoggedMessages logger of
   Just _ -> pure ()
  where
   loggerSet = getLoggerLoggerSet logger
-
-class HasLogger env where
-  loggerL :: Lens' env Logger
-
-instance HasLogger Logger where
-  loggerL = id
 
 newLogger :: MonadIO m => LogSettings -> m Logger
 newLogger settings = do


### PR DESCRIPTION
### [Move Logger type down to an Internal module](https://github.com/freckle/blammo/pull/31/commits/8f8cd9e358ad87593c2e3f7d81e63da9d104401d)
[8f8cd9e](https://github.com/freckle/blammo/pull/31/commits/8f8cd9e358ad87593c2e3f7d81e63da9d104401d)

This will allow some modules that want to depend on it, but that Logger
depends on, make use of it -- such as to add Logger-specific behavior to
colors.

### [Add more convenience functions to Colors module](https://github.com/freckle/blammo/pull/31/commits/7482f7887c70aba8cda542a01bc1604497547c56)
[7482f78](https://github.com/freckle/blammo/pull/31/commits/7482f7887c70aba8cda542a01bc1604497547c56)

These were implemented externally in a few apps and are very useful.

---

I'm not a huge fan of the `.Internal` pattern, but in this case it saves us from a different kind of re-organization of modules that would incur a major version bump.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204750280206924