### PR TITLE
Document usage without LoggingT

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -97,6 +97,8 @@ test-suite readme
     , aeson
     , base <5
     , markdown-unlit
+    , monad-logger
+    , mtl
     , text
   default-language: Haskell2010
   if impl(ghc >= 9.2)

--- a/package.yaml
+++ b/package.yaml
@@ -85,8 +85,8 @@ tests:
     main: README.lhs
     ghc-options: -pgmL markdown-unlit
     dependencies:
-      - aeson
       - Blammo
+      - aeson
       - markdown-unlit
       - monad-logger
       - mtl

--- a/package.yaml
+++ b/package.yaml
@@ -85,7 +85,9 @@ tests:
     main: README.lhs
     ghc-options: -pgmL markdown-unlit
     dependencies:
-      - Blammo
       - aeson
+      - Blammo
       - markdown-unlit
+      - monad-logger
+      - mtl
       - text


### PR DESCRIPTION
## Overview

- Add an example to `README.lhs` of using Blammo without `LoggingT`, by extracting the log function with `askLoggerIO`

## Context

I was working on refactoring a codebase from a monad transformer stack to the so-called "ReaderT IO" pattern. I had figured out how to remove `LoggingT` and implement a custom `MonadLogger` instance, as well as create the "log function" using `defaultOutput` from `monad-logger` or `monad-logger-aeson`, but it wasn't obvious at first how to do this with `Blammo`.

Looking at the RIO and Amazonka examples gave me the idea to use `askLoggerIO`. Let me know if this is the correct way to do this? If it is, I thought it could be useful to have a dedicated example in the README?