### PR TITLE
Improve ENV-based configuration

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -74,6 +74,8 @@ library
     , vector
     , wai
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)
@@ -101,6 +103,8 @@ test-suite readme
     , mtl
     , text
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)
@@ -136,6 +140,8 @@ test-suite spec
     , text
     , time
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.2.1
+version:        1.1.2.2
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -111,6 +111,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Blammo.Logging.LoggerSpec
+      Blammo.Logging.LogSettings.EnvSpec
       Blammo.Logging.LogSettings.LogLevelsSpec
       Blammo.Logging.TerminalSpec
       Paths_Blammo
@@ -129,6 +130,7 @@ test-suite spec
     , aeson
     , base <5
     , bytestring
+    , envparse
     , hspec
     , mtl
     , text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.1...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.2...main)
+
+## [v1.1.2.2](https://github.com/freckle/blammo/compare/v1.1.2.1...v1.1.2.2)
+
+- Don't automatically colorize if `TERM=dumb` is found in ENV
+- Respect [`NO_COLOR`](http://no-color.org/)
+- Automatically adjust log concurrency based on `LOG_FORMAT`:
+
+  Disable concurrency for `tty` (making that the new default) and enable it for
+  `json`. Setting `LOG_CONCURRENCY` will still be respected.
 
 ## [v1.1.2.1](https://github.com/freckle/blammo/compare/v1.1.2.0...v1.1.2.1)
 

--- a/README.lhs
+++ b/README.lhs
@@ -134,10 +134,8 @@ performance and a lower tolerance for the confusion of out of order messages.
 
 For this reason, the default behavior is to _not_ use concurrent logging, but
 setting the format to `json` will automatically enable it (with
-{number-of-cores} as the value).
-
-If you want to handle this explicitly, you can set `LOG_CONCURRENCY`; just be
-sure to do it after `LOG_FORMAT`.
+{number-of-cores} as the value). To handle this explicitly, set
+`LOG_CONCURRENCY`.
 
 [fast-logger]: https://hackage.haskell.org/package/fast-logger
 

--- a/README.lhs
+++ b/README.lhs
@@ -1,6 +1,5 @@
 # Blammo
 
-
 [![Hackage](https://img.shields.io/hackage/v/Blammo.svg?style=flat)](https://hackage.haskell.org/package/Blammo)
 [![Stackage Nightly](http://stackage.org/package/Blammo/badge/nightly)](http://stackage.org/nightly/package/Blammo)
 [![Stackage LTS](http://stackage.org/package/Blammo/badge/lts)](http://stackage.org/lts/package/Blammo)
@@ -127,14 +126,18 @@ large number to disable this feature.
 ## Out of Order Messages
 
 Blammo is built on [fast-logger], which offers concurrent logging through
-multiple buffers. By default, it uses {number-of-processors} buffers. This
-concurrent logging is fast, but may deliver messages out of order. You want this
-on production: your aggregator should be inspecting the message's time-stamp to
-re-order as necessary on the other side. However, this can be problematic in a
-CLI, where there is both little need for such high performance and a lower
-tolerance for the confusion of out of order messages.
+multiple buffers. This concurrent logging is fast, but may deliver messages out
+of order. You want this on production: your aggregator should be inspecting the
+message's time-stamp to re-order as necessary on the other side. However, this
+can be problematic in a CLI, where there is both little need for such high
+performance and a lower tolerance for the confusion of out of order messages.
 
-For such cases, you can set `LOG_CONCURRENCY=1` to use a single buffer.
+For this reason, the default behavior is to _not_ use concurrent logging, but
+setting the format to `json` will automatically enable it (with
+{number-of-cores} as the value).
+
+If you want to handle this explicitly, you can set `LOG_CONCURRENCY`; just be
+sure to do it after `LOG_FORMAT`.
 
 [fast-logger]: https://hackage.haskell.org/package/fast-logger
 
@@ -142,6 +145,7 @@ For such cases, you can set `LOG_CONCURRENCY=1` to use a single buffer.
 
 | Setting     | Setter                      | Environment variable and format           |
 | ---         | ---                         | ---                                       |
+| Format      | `setLogSettingsFormat`      | `LOG_FORMAT=tty\|json`                    |
 | Level(s)    | `setLogSettingsLevels`      | `LOG_LEVEL=<level>[,<source:level>,...]`  |
 | Destination | `setLogSettingsDestination` | `LOG_DESTINATION=stdout\|stderr\|@<path>` |
 | Color       | `setLogSettingsColor `      | `LOG_COLOR=auto\|always\|never`           |

--- a/package.yaml
+++ b/package.yaml
@@ -75,6 +75,7 @@ tests:
     dependencies:
       - Blammo
       - aeson
+      - envparse
       - bytestring
       - hspec
       - mtl

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,9 @@ ghc-options:
   - -Wno-unsafe
 
 when:
+  - condition: "impl(ghc >= 9.8)"
+    ghc-options:
+      - -Wno-missing-role-annotations
   - condition: "impl(ghc >= 9.2)"
     ghc-options:
       - -Wno-missing-kind-signatures

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.2.1
+version: 1.1.2.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Blammo/Logging/LogSettings.hs
+++ b/src/Blammo/Logging/LogSettings.hs
@@ -86,6 +86,7 @@ data LogColor
   = LogColorAuto
   | LogColorAlways
   | LogColorNever
+  deriving stock (Eq, Show)
 
 readLogColor :: String -> Either String LogColor
 readLogColor x

--- a/src/Blammo/Logging/LogSettings.hs
+++ b/src/Blammo/Logging/LogSettings.hs
@@ -115,7 +115,7 @@ defaultLogSettings =
     , lsFormat = LogFormatTerminal
     , lsColor = LogColorAuto
     , lsBreakpoint = 120
-    , lsConcurrency = Nothing
+    , lsConcurrency = Just 1
     }
 
 setLogSettingsLevels :: LogLevels -> LogSettings -> LogSettings
@@ -125,7 +125,17 @@ setLogSettingsDestination :: LogDestination -> LogSettings -> LogSettings
 setLogSettingsDestination x ls = ls {lsDestination = x}
 
 setLogSettingsFormat :: LogFormat -> LogSettings -> LogSettings
-setLogSettingsFormat x ls = ls {lsFormat = x}
+setLogSettingsFormat x ls = case x of
+  LogFormatTerminal ->
+    ls
+      { lsFormat = x
+      , lsConcurrency = Just 1
+      }
+  _ ->
+    ls
+      { lsFormat = x
+      , lsConcurrency = Nothing
+      }
 
 setLogSettingsColor :: LogColor -> LogSettings -> LogSettings
 setLogSettingsColor x ls = ls {lsColor = x}
@@ -135,9 +145,9 @@ setLogSettingsBreakpoint x ls = ls {lsBreakpoint = x}
 
 -- | Set the number of 'LoggerSet' Buffers used by @fast-logger@
 --
--- By default this matches 'getNumCapabilities', which is more performant but
--- does not guarantee message order. If this matters, such as in a CLI, set this
--- value to @1@.
+-- A value of 'Nothing' means to use 'getNumCapabilities'. Higher is more
+-- performant, but may deliver messages out of order. The defualt is set for TTY
+-- usage (so, @1@), but is also changed through 'setLogSettingsFormat' is used.
 --
 -- Support for this option depends on your version of @fast-logger@:
 --

--- a/src/Blammo/Logging/LogSettings/Env.hs
+++ b/src/Blammo/Logging/LogSettings/Env.hs
@@ -14,6 +14,13 @@
 --   recognized (e.g. @yes@ or @no@) but should not be relied on. Unrecognized
 --   values will produce an error
 --
+-- - @LOG_BREAKPOINT@: a number representing the column-width at which to break
+--   into multi-line format.
+--
+-- - @LOG_CONCURRENCY@: number of log buffers to use. More will perform faster
+--   but result in out-of-order delivery. This is automatically disabled for
+--   @LOG_FORMAT=tty@ and set to /number-of-cores/ for @LOG_FORMAT=json@.
+--
 -- This module is meant to be imported @qualified@.
 --
 -- @
@@ -67,10 +74,10 @@ parserWith defaults =
     <$> sequenceA
       [ var (endo readLogLevels setLogSettingsLevels) "LOG_LEVEL" (def mempty)
       , var (endo readLogDestination setLogSettingsDestination) "LOG_DESTINATION" (def mempty)
-      , var (endo readLogFormat setLogSettingsFormat) "LOG_FORMAT" (def mempty)
       , var (endo readLogColor setLogSettingsColor) "LOG_COLOR" (def mempty)
       , var (endo readEither setLogSettingsBreakpoint) "LOG_BREAKPOINT" (def mempty)
       , var (endo readEither (setLogSettingsConcurrency . Just)) "LOG_CONCURRENCY" (def mempty)
+      , var (endo readLogFormat setLogSettingsFormat) "LOG_FORMAT" (def mempty)
       ]
 
 endo

--- a/tests/Blammo/Logging/LogSettings/EnvSpec.hs
+++ b/tests/Blammo/Logging/LogSettings/EnvSpec.hs
@@ -1,0 +1,94 @@
+module Blammo.Logging.LogSettings.EnvSpec
+  ( spec
+  ) where
+
+import Prelude
+
+import Blammo.Logging.LogSettings
+import qualified Blammo.Logging.LogSettings.Env as LogSettingsEnv
+import Blammo.Logging.LogSettings.LogLevels
+import Data.List (intercalate)
+import qualified Env
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  context "LOG_LEVEL" $ do
+    it "reads a simple log-level" $ do
+      let env = [("LOG_LEVEL", "debug")]
+
+      settings <- parseLogSettings env
+      getLogSettingsLevels settings `shouldBe` newLogLevels LevelDebug []
+
+  context "LOG_FORMAT and LOG_CONCURRENCY" $ do
+    it "Sets LOG_CONCURRENCY if format is tty" $ do
+      settings <- parseLogSettings []
+      settingsTTY <- parseLogSettings [("LOG_FORMAT", "tty")]
+
+      getLogSettingsConcurrency settings `shouldBe` Just 1
+      getLogSettingsConcurrency settingsTTY `shouldBe` Just 1
+
+    it "Unsets LOG_CONCURRENCY if format is not tty" $ do
+      settings <- parseLogSettings []
+      settingsJSON <- parseLogSettings [("LOG_FORMAT", "json")]
+
+      getLogSettingsConcurrency settings `shouldBe` Just 1
+      getLogSettingsConcurrency settingsJSON `shouldBe` Nothing
+
+    it "Respects explicit LOG_CONCURRENCY" $ do
+      settingsTTY <- parseLogSettings [("LOG_FORMAT", "tty"), ("LOG_CONCURRENCY", "2")]
+      settingsJSON <- parseLogSettings [("LOG_FORMAT", "json"), ("LOG_CONCURRENCY", "3")]
+
+      getLogSettingsConcurrency settingsTTY `shouldBe` Just 2
+      getLogSettingsConcurrency settingsJSON `shouldBe` Just 3
+
+  context "NO_COLOR" $ do
+    it "changes LOG_COLOR to never" $ do
+      settings <- parseLogSettings []
+      settingsC <- parseLogSettings [("NO_COLOR", "")]
+      settingsNC <- parseLogSettings [("NO_COLOR", "x")]
+
+      getLogSettingsColor settings `shouldBe` LogColorAuto
+      getLogSettingsColor settingsC `shouldBe` LogColorAuto
+      getLogSettingsColor settingsNC `shouldBe` LogColorNever
+
+    it "respects explicit LOG_COLOR after" $ do
+      settings <- parseLogSettings [("NO_COLOR", "x"), ("LOG_COLOR", "always")]
+
+      getLogSettingsColor settings `shouldBe` LogColorAlways
+
+  context "TERM=dumb" $ do
+    it "changes LOG_COLOR to never" $ do
+      settings <- parseLogSettings []
+      settingsC <- parseLogSettings [("TERM", "xterm")]
+      settingsNC <- parseLogSettings [("TERM", "dumb")]
+
+      getLogSettingsColor settings `shouldBe` LogColorAuto
+      getLogSettingsColor settingsC `shouldBe` LogColorAuto
+      getLogSettingsColor settingsNC `shouldBe` LogColorNever
+
+    it "respects explicit LOG_COLOR after" $ do
+      settings <- parseLogSettings [("TERM", "dumb"), ("LOG_COLOR", "always")]
+
+      getLogSettingsColor settings `shouldBe` LogColorAlways
+
+-- context "TERM=dumb" $ do
+
+parseLogSettings :: [(String, String)] -> IO LogSettings
+parseLogSettings env = do
+  case Env.parsePure LogSettingsEnv.parser env of
+    Left es -> expectationFailure (failureMessage es) *> error "Unreachable"
+    Right s -> pure s
+ where
+  failureMessage :: [(String, Env.Error)] -> String
+  failureMessage =
+    ("Expected parse to succeed, but there were errors:\n" <>)
+      . intercalate "\n  "
+      . map showEnvError
+
+  showEnvError :: (String, Env.Error) -> String
+  showEnvError (name, e) =
+    name <> " :" <> case e of
+      Env.UnsetError -> "expected, but not set"
+      Env.EmptyError -> "expected, but was empty"
+      Env.UnreadError x -> "invalid: " <> show x

--- a/tests/Blammo/Logging/LogSettings/EnvSpec.hs
+++ b/tests/Blammo/Logging/LogSettings/EnvSpec.hs
@@ -34,10 +34,14 @@ spec = do
       getLogSettingsConcurrency settings `shouldBe` Nothing
 
     it "Respects explicit LOG_CONCURRENCY" $ do
-      settingsTTY1 <- parseLogSettings [("LOG_CONCURRENCY", "2"), ("LOG_FORMAT", "tty")]
-      settingsTTY2 <- parseLogSettings [("LOG_FORMAT", "tty"), ("LOG_CONCURRENCY", "3")]
-      settingsJSON1 <- parseLogSettings [("LOG_FORMAT", "json"), ("LOG_CONCURRENCY", "4")]
-      settingsJSON2 <- parseLogSettings [("LOG_CONCURRENCY", "5"), ("LOG_FORMAT", "json")]
+      settingsTTY1 <-
+        parseLogSettings [("LOG_CONCURRENCY", "2"), ("LOG_FORMAT", "tty")]
+      settingsTTY2 <-
+        parseLogSettings [("LOG_FORMAT", "tty"), ("LOG_CONCURRENCY", "3")]
+      settingsJSON1 <-
+        parseLogSettings [("LOG_FORMAT", "json"), ("LOG_CONCURRENCY", "4")]
+      settingsJSON2 <-
+        parseLogSettings [("LOG_CONCURRENCY", "5"), ("LOG_FORMAT", "json")]
 
       getLogSettingsConcurrency settingsTTY1 `shouldBe` Just 2
       getLogSettingsConcurrency settingsTTY2 `shouldBe` Just 3

--- a/tests/Blammo/Logging/LogSettings/EnvSpec.hs
+++ b/tests/Blammo/Logging/LogSettings/EnvSpec.hs
@@ -29,18 +29,20 @@ spec = do
       getLogSettingsConcurrency settingsTTY `shouldBe` Just 1
 
     it "Unsets LOG_CONCURRENCY if format is not tty" $ do
-      settings <- parseLogSettings []
-      settingsJSON <- parseLogSettings [("LOG_FORMAT", "json")]
+      settings <- parseLogSettings [("LOG_FORMAT", "json")]
 
-      getLogSettingsConcurrency settings `shouldBe` Just 1
-      getLogSettingsConcurrency settingsJSON `shouldBe` Nothing
+      getLogSettingsConcurrency settings `shouldBe` Nothing
 
     it "Respects explicit LOG_CONCURRENCY" $ do
-      settingsTTY <- parseLogSettings [("LOG_FORMAT", "tty"), ("LOG_CONCURRENCY", "2")]
-      settingsJSON <- parseLogSettings [("LOG_FORMAT", "json"), ("LOG_CONCURRENCY", "3")]
+      settingsTTY1 <- parseLogSettings [("LOG_CONCURRENCY", "2"), ("LOG_FORMAT", "tty")]
+      settingsTTY2 <- parseLogSettings [("LOG_FORMAT", "tty"), ("LOG_CONCURRENCY", "3")]
+      settingsJSON1 <- parseLogSettings [("LOG_FORMAT", "json"), ("LOG_CONCURRENCY", "4")]
+      settingsJSON2 <- parseLogSettings [("LOG_CONCURRENCY", "5"), ("LOG_FORMAT", "json")]
 
-      getLogSettingsConcurrency settingsTTY `shouldBe` Just 2
-      getLogSettingsConcurrency settingsJSON `shouldBe` Just 3
+      getLogSettingsConcurrency settingsTTY1 `shouldBe` Just 2
+      getLogSettingsConcurrency settingsTTY2 `shouldBe` Just 3
+      getLogSettingsConcurrency settingsJSON1 `shouldBe` Just 4
+      getLogSettingsConcurrency settingsJSON2 `shouldBe` Just 5
 
   context "NO_COLOR" $ do
     it "changes LOG_COLOR to never" $ do
@@ -53,9 +55,11 @@ spec = do
       getLogSettingsColor settingsNC `shouldBe` LogColorNever
 
     it "respects explicit LOG_COLOR after" $ do
-      settings <- parseLogSettings [("NO_COLOR", "x"), ("LOG_COLOR", "always")]
+      settings1 <- parseLogSettings [("LOG_COLOR", "always"), ("NO_COLOR", "x")]
+      settings2 <- parseLogSettings [("NO_COLOR", "x"), ("LOG_COLOR", "always")]
 
-      getLogSettingsColor settings `shouldBe` LogColorAlways
+      getLogSettingsColor settings1 `shouldBe` LogColorAlways
+      getLogSettingsColor settings2 `shouldBe` LogColorAlways
 
   context "TERM=dumb" $ do
     it "changes LOG_COLOR to never" $ do
@@ -68,11 +72,11 @@ spec = do
       getLogSettingsColor settingsNC `shouldBe` LogColorNever
 
     it "respects explicit LOG_COLOR after" $ do
-      settings <- parseLogSettings [("TERM", "dumb"), ("LOG_COLOR", "always")]
+      settings1 <- parseLogSettings [("LOG_COLOR", "always"), ("TERM", "dumb")]
+      settings2 <- parseLogSettings [("TERM", "dumb"), ("LOG_COLOR", "always")]
 
-      getLogSettingsColor settings `shouldBe` LogColorAlways
-
--- context "TERM=dumb" $ do
+      getLogSettingsColor settings1 `shouldBe` LogColorAlways
+      getLogSettingsColor settings2 `shouldBe` LogColorAlways
 
 parseLogSettings :: [(String, String)] -> IO LogSettings
 parseLogSettings env = do


### PR DESCRIPTION
### [Handle LOG_FORMAT and LOG_CONCURRENCY together](https://github.com/freckle/blammo/pull/38/commits/3de1d1d3d09e41f0a4b7d6261713389f403f16b5)
[3de1d1d](https://github.com/freckle/blammo/pull/38/commits/3de1d1d3d09e41f0a4b7d6261713389f403f16b5)

This changes the default value for concurrency to `Just 1`, which is
better for CLIs. The defaults are CLI-oriented, so this is effectively a
bug fix and simplifies end user story around concurrency.

Additionally, `setLogSettingsFormat` now updates concurrency too:

- If setting to `tty` disable concurrency (`Just 1`)
- If setting to `json` enable it (`Nothing` -> num-cores)

The changes were also further described in the README and Haddocks.

Closes https://github.com/freckle/blammo/issues/35.

### [Disable color of NO_COLOR or TERM=dumb](https://github.com/freckle/blammo/pull/38/commits/214bebd35cb12d0970312a2c4641a456b74f3286)
[214bebd](https://github.com/freckle/blammo/pull/38/commits/214bebd35cb12d0970312a2c4641a456b74f3286)

For both cases, we set things to `LOG_COLOR=never`. An explicit
`LOG_COLOR` coming after will still be respected though.

Closes https://github.com/freckle/blammo/issues/32.

### [Add tests for LogSettings.Env](https://github.com/freckle/blammo/pull/38/commits/86e9aeca67c1845fa22a95df3d53f2b3875a4aa2)
[86e9aec](https://github.com/freckle/blammo/pull/38/commits/86e9aeca67c1845fa22a95df3d53f2b3875a4aa2)