### PR TITLE
Delay for 0.1s when flushing

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.2.2
+version:        1.1.2.3
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.2...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.3...main)
+
+## [v1.1.2.3](https://github.com/freckle/blammo/compare/v1.1.2.2...v1.1.2.3)
+
+- Add small delay (0.1s) in `flushLogger` to work around fast-logger bug
 
 ## [v1.1.2.2](https://github.com/freckle/blammo/compare/v1.1.2.1...v1.1.2.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.2.2
+version: 1.1.2.3
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/src/Blammo/Logging/Logger.hs
+++ b/src/Blammo/Logging/Logger.hs
@@ -27,6 +27,7 @@ import Blammo.Logging.LogSettings
 import Blammo.Logging.Terminal
 import Blammo.Logging.Test hiding (getLoggedMessages)
 import qualified Blammo.Logging.Test as LoggedMessages
+import Control.Concurrent (threadDelay)
 import Control.Lens (view)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -82,7 +83,11 @@ pushLogStrLn logger str = case lLoggedMessages logger of
 
 flushLogStr :: MonadIO m => Logger -> m ()
 flushLogStr logger = case lLoggedMessages logger of
-  Nothing -> liftIO $ FastLogger.flushLogStr loggerSet
+  Nothing -> liftIO $ do
+    -- Delay for 0.1s before flushing to work around
+    -- https://github.com/kazu-yamamoto/logger/issues/213
+    threadDelay 100000
+    FastLogger.flushLogStr loggerSet
   Just _ -> pure ()
  where
   loggerSet = getLoggerLoggerSet logger


### PR DESCRIPTION
fast-logger has a bug[^1] where flushing immediately after pushing a log
message sometimes does not find anything to flush. Typically, users will
flush the log because they intend to print non-logging output or as part
of program exit. This bug causes output to be interleaved incorrectly in
the former case and log messages to be lost entirely in the latter.

To work around this, we delay 0.1s before flushing. There's no guarantee
this works, and I don't know if the delay could be shorter or should be
longer, but it has made things work reliably in my testing so far.

[^1]: https://github.com/kazu-yamamoto/logger/issues/213
