### PR TITLE
Require latest fast-logger and remove workaround

### DIFF
--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.2.3
+version:        1.1.3.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils
@@ -61,7 +61,7 @@ library
     , dlist
     , envparse
     , exceptions
-    , fast-logger
+    , fast-logger >=3.2.3
     , http-types
     , lens
     , monad-logger-aeson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.2.3...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.3.0...main)
+
+## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
+
+- Update fast-logger to fix log flushing bug, and remove 0.1s delay that was
+  introduced as a workaround.
 
 ## [v1.1.2.3](https://github.com/freckle/blammo/compare/v1.1.2.2...v1.1.2.3)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.2.3
+version: 1.1.3.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo
@@ -52,7 +52,7 @@ library:
     - dlist
     - envparse
     - exceptions
-    - fast-logger
+    - fast-logger >= 3.2.3 # fix for bad flush behavior
     - lens
     - monad-logger-aeson
     - mtl

--- a/src/Blammo/Logging/Logger.hs
+++ b/src/Blammo/Logging/Logger.hs
@@ -27,7 +27,6 @@ import Blammo.Logging.LogSettings
 import Blammo.Logging.Terminal
 import Blammo.Logging.Test hiding (getLoggedMessages)
 import qualified Blammo.Logging.Test as LoggedMessages
-import Control.Concurrent (threadDelay)
 import Control.Lens (view)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -83,11 +82,7 @@ pushLogStrLn logger str = case lLoggedMessages logger of
 
 flushLogStr :: MonadIO m => Logger -> m ()
 flushLogStr logger = case lLoggedMessages logger of
-  Nothing -> liftIO $ do
-    -- Delay for 0.1s before flushing to work around
-    -- https://github.com/kazu-yamamoto/logger/issues/213
-    threadDelay 100000
-    FastLogger.flushLogStr loggerSet
+  Nothing -> liftIO $ FastLogger.flushLogStr loggerSet
   Just _ -> pure ()
  where
   loggerSet = getLoggerLoggerSet logger

--- a/stack-lts-12.26.yaml
+++ b/stack-lts-12.26.yaml
@@ -1,7 +1,9 @@
 resolver: lts-12.26
 extra-deps:
   - envparse-0.5.0
-  - monad-logger-aeson-0.3.0.2
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3
 
   # See https://github.com/jship/monad-logger-aeson/blob/main/stack-lts-12.yaml
   - QuickCheck-2.13.1
@@ -17,5 +19,6 @@ extra-deps:
   - tagged-0.8.6
   - these-1.1
   - time-compat-1.9.2.2
+  - unix-time-0.4.4
   - unordered-containers-0.2.10.0
   - vector-algorithms-0.8.0.1

--- a/stack-lts-12.26.yaml.lock
+++ b/stack-lts-12.26.yaml.lock
@@ -7,125 +7,146 @@ packages:
 - completed:
     hackage: envparse-0.5.0@sha256:ba9ad793ed2fcfce644b3ebb8eb6c2fef2e44924f75e1b324956340e664c416e,2849
     pantry-tree:
-      size: 1181
       sha256: 419a6843224ad32755064276f8e36500c71238db1b5807a2c9596fa4ed909a5a
+      size: 1181
   original:
     hackage: envparse-0.5.0
 - completed:
-    hackage: monad-logger-aeson-0.3.0.2@sha256:28b424cef9799aa4a3e8680431dd571ba07b2fb05d4928703c209ee07a0c0a97,5193
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
     pantry-tree:
-      size: 5103
-      sha256: 9650ba64ec9e7eacb0ea6132c262ad458c78dfa9bc29cee5ade8c0bd8994cb27
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
   original:
-    hackage: monad-logger-aeson-0.3.0.2
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 - completed:
     hackage: QuickCheck-2.13.1@sha256:729061db99e45eb60dfe67e04dce0cc6656e80a74f07f8d60eefb44dce8de1f6,6772
     pantry-tree:
-      size: 2202
       sha256: e7ac8b9d8cc3bd33e2e46b0427d4b1a0824776f275ceb7ef5aa9e55ca5dcb9de
+      size: 2202
   original:
     hackage: QuickCheck-2.13.1
 - completed:
     hackage: aeson-1.5.2.0@sha256:d00c7aa51969b2849550e4dee14c9ce188504d55ed8d7f734ce9f6976db452f6,6786
     pantry-tree:
-      size: 39758
       sha256: 992b01282d72e4db664289db69a846a4ec675379ca96824ba902a7541104d409
+      size: 39758
   original:
     hackage: aeson-1.5.2.0
 - completed:
     hackage: assoc-1@sha256:8d32ce39b6b6ce15394e9346f9ddb8752885aaa506a603e65d1c2769aff79741,1024
     pantry-tree:
-      size: 238
       sha256: a0ed2f5cc46ee2dbd01834788d98d903154c883d056b81765eec4861ec3efb45
+      size: 238
   original:
     hackage: assoc-1
 - completed:
     hackage: base-orphans-0.8.1@sha256:defd0057b5db93257528d89b5b01a0fee9738e878c121c686948ac4aa5dded63,2927
     pantry-tree:
-      size: 1272
       sha256: e059f342ae4cd1edcbd90f5f69caab550a00cc64abcfd198ede188391ffe151f
+      size: 1272
   original:
     hackage: base-orphans-0.8.1
 - completed:
     hackage: context-0.2.0.1@sha256:b5a1390a5ad11b7edd0449c9ef96823f082bff4988bd09583e37a4e93e9aad10,1891
     pantry-tree:
-      size: 952
       sha256: ebb043dd007864588c6b1676a0d30e521deab4353a3f19716f6f6f7d52b62817
+      size: 952
   original:
     hackage: context-0.2.0.1
 - completed:
     hackage: hspec-2.7.9@sha256:74cc9958698d9964047072971cb5557c95ebb4ee8a605d8a9458ac86a41da6ec,1709
     pantry-tree:
-      size: 583
       sha256: 0505115fce89d92eea16223d996e7aae57302c83d588db0de84abdd1b110a230
+      size: 583
   original:
     hackage: hspec-2.7.9
 - completed:
     hackage: hspec-core-2.7.9@sha256:5153ef21166ad380abf800cae27a3956ed5409bf1a1f1b58356733747a03bff5,4730
     pantry-tree:
-      size: 3886
       sha256: f07977ee2b6f33671b4fa993f579179f2b07b78a4d8cd2a1989b537afaeb0360
+      size: 3886
   original:
     hackage: hspec-core-2.7.9
 - completed:
     hackage: hspec-discover-2.7.9@sha256:7b16072af84135b8a66c4fd2cce3a9b30d0a6509ac4ca6cb4394ab038efc8ed5,2183
     pantry-tree:
-      size: 1131
       sha256: ee98d716f75904f3d7359c2a4df85cddff94e70befd6a687d5d8c17346cecaed
+      size: 1131
   original:
     hackage: hspec-discover-2.7.9
 - completed:
     hackage: primitive-0.7.4.0@sha256:89b88a3e08493b7727fa4089b0692bfbdf7e1e666ef54635f458644eb8358764,2857
     pantry-tree:
-      size: 1655
       sha256: 71a850c658b70e869da19f61615d87d9d6ecec597f0e3d4b498da56559114829
+      size: 1655
   original:
     hackage: primitive-0.7.4.0
 - completed:
     hackage: splitmix-0.0.2@sha256:e1c4d1202757d63cd4b4498d5fa600a792f2a315d2fdc6cf772f4679113c1819,3298
     pantry-tree:
-      size: 496
       sha256: b5947f7eb9a466b0e60b4fa71e20ffcf9ce089505ea8ee89b04bd47eb8706365
+      size: 496
   original:
     hackage: splitmix-0.0.2
 - completed:
     hackage: tagged-0.8.6@sha256:7cce0b9355d1daad797555dfa906f756ed0253a40bc826ca367adf21d7b369f3,2606
     pantry-tree:
-      size: 543
       sha256: a3eca0faaf7a4b2d415a8d700af434b65e58ccd7f6e353b0ac3435c308389681
+      size: 543
   original:
     hackage: tagged-0.8.6
 - completed:
     hackage: these-1.1@sha256:18ff38deaaf314cec509f9bd41c2a7a2a6b64210846eed89976173534b5bccb6,2650
     pantry-tree:
-      size: 351
       sha256: 3b40e44bbd8f184b5c4a1a3134a4a0826a2aa03cd8b33f2e6533bd336e6f9fe8
+      size: 351
   original:
     hackage: these-1.1
 - completed:
     hackage: time-compat-1.9.2.2@sha256:ccf268e6ec91a6d9a79392697634c670c095a34a60d1ccfa1be1c84f20bb24c5,4254
     pantry-tree:
-      size: 3602
       sha256: f16cc56a43fa6047ad46b23770d5a16b9c400fd8d019e9b010b766a13e8eb588
+      size: 3602
   original:
     hackage: time-compat-1.9.2.2
 - completed:
+    hackage: unix-time-0.4.4@sha256:31feaa4a700bce765f9293f5e1167a43d862d3f2cb5f928dc8289575f1515272,2575
+    pantry-tree:
+      sha256: e161021f104c78008e42ef0ef88d512e7465cc6ce91c20d1220481ac2b7f2347
+      size: 1073
+  original:
+    hackage: unix-time-0.4.4
+- completed:
     hackage: unordered-containers-0.2.10.0@sha256:5e9b095a9283d9e2f064fec73a81a6b6ea0b7fda3f219a8175785d2d2a3de204,5199
     pantry-tree:
-      size: 1415
       sha256: dfc2d75f4e59c03e2c68be6909b577f26991367134eaac06a407e940e66856ae
+      size: 1415
   original:
     hackage: unordered-containers-0.2.10.0
 - completed:
     hackage: vector-algorithms-0.8.0.1@sha256:8496dd4b5e79c37c064e69ce20c5bb31048dfb4b59ce43de6a01b5d0fa384457,3616
     pantry-tree:
-      size: 1387
       sha256: b8e536953c2268f6d2d50f8fcffa1316cf3cf35c1288a18d9053f426ab967235
+      size: 1387
   original:
     hackage: vector-algorithms-0.8.0.1
 snapshots:
 - completed:
+    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
     size: 509471
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/12/26.yaml
-    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
   original: lts-12.26

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,7 +1,9 @@
 resolver: lts-14.27
 extra-deps:
   - envparse-0.5.0
-  - monad-logger-aeson-0.3.0.2
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3
 
   # See https://github.com/jship/monad-logger-aeson/blob/main/stack-lts-14.yaml
   - aeson-1.5.2.0

--- a/stack-lts-14.27.yaml.lock
+++ b/stack-lts-14.27.yaml.lock
@@ -7,69 +7,83 @@ packages:
 - completed:
     hackage: envparse-0.5.0@sha256:ba9ad793ed2fcfce644b3ebb8eb6c2fef2e44924f75e1b324956340e664c416e,2849
     pantry-tree:
-      size: 1181
       sha256: 419a6843224ad32755064276f8e36500c71238db1b5807a2c9596fa4ed909a5a
+      size: 1181
   original:
     hackage: envparse-0.5.0
 - completed:
-    hackage: monad-logger-aeson-0.3.0.2@sha256:28b424cef9799aa4a3e8680431dd571ba07b2fb05d4928703c209ee07a0c0a97,5193
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
     pantry-tree:
-      size: 5103
-      sha256: 9650ba64ec9e7eacb0ea6132c262ad458c78dfa9bc29cee5ade8c0bd8994cb27
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
   original:
-    hackage: monad-logger-aeson-0.3.0.2
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 - completed:
     hackage: aeson-1.5.2.0@sha256:d00c7aa51969b2849550e4dee14c9ce188504d55ed8d7f734ce9f6976db452f6,6786
     pantry-tree:
-      size: 39758
       sha256: 992b01282d72e4db664289db69a846a4ec675379ca96824ba902a7541104d409
+      size: 39758
   original:
     hackage: aeson-1.5.2.0
 - completed:
     hackage: context-0.2.0.1@sha256:b5a1390a5ad11b7edd0449c9ef96823f082bff4988bd09583e37a4e93e9aad10,1891
     pantry-tree:
-      size: 952
       sha256: ebb043dd007864588c6b1676a0d30e521deab4353a3f19716f6f6f7d52b62817
+      size: 952
   original:
     hackage: context-0.2.0.1
 - completed:
     hackage: hspec-2.7.9@sha256:74cc9958698d9964047072971cb5557c95ebb4ee8a605d8a9458ac86a41da6ec,1709
     pantry-tree:
-      size: 583
       sha256: 0505115fce89d92eea16223d996e7aae57302c83d588db0de84abdd1b110a230
+      size: 583
   original:
     hackage: hspec-2.7.9
 - completed:
-    hackage: hspec-core-2.7.9@sha256:5153ef21166ad380abf800cae27a3956ed5409bf1a1f1b58356733747a03bff5,4730
+    hackage: hspec-core-2.7.9@sha256:c17d18974f057edb662dca266cc114c0650f1d5674e0ddc65969137e92feb946,4748
     pantry-tree:
+      sha256: c510d5513116c815a5a675eb09e8d1ad79e8efcd8d482bfd3734335b35499e04
       size: 3886
-      sha256: f07977ee2b6f33671b4fa993f579179f2b07b78a4d8cd2a1989b537afaeb0360
   original:
     hackage: hspec-core-2.7.9
 - completed:
     hackage: hspec-discover-2.7.9@sha256:7b16072af84135b8a66c4fd2cce3a9b30d0a6509ac4ca6cb4394ab038efc8ed5,2183
     pantry-tree:
-      size: 1131
       sha256: ee98d716f75904f3d7359c2a4df85cddff94e70befd6a687d5d8c17346cecaed
+      size: 1131
   original:
     hackage: hspec-discover-2.7.9
 - completed:
-    hackage: primitive-0.7.4.0@sha256:89b88a3e08493b7727fa4089b0692bfbdf7e1e666ef54635f458644eb8358764,2857
+    hackage: primitive-0.7.4.0@sha256:c2f0ed97b3dce97f2f43b239c3be8b136e4368f1eb7b61322ee9ac98f604622b,2982
     pantry-tree:
+      sha256: 1cd1f40729b3038f1140fbf506ce59ab2db3f745b1727e0beba6390621aa9630
       size: 1655
-      sha256: 71a850c658b70e869da19f61615d87d9d6ecec597f0e3d4b498da56559114829
   original:
     hackage: primitive-0.7.4.0
 - completed:
     hackage: these-1.1@sha256:18ff38deaaf314cec509f9bd41c2a7a2a6b64210846eed89976173534b5bccb6,2650
     pantry-tree:
-      size: 351
       sha256: 3b40e44bbd8f184b5c4a1a3134a4a0826a2aa03cd8b33f2e6533bd336e6f9fe8
+      size: 351
   original:
     hackage: these-1.1
 snapshots:
 - completed:
+    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
     size: 524996
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
-    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
   original: lts-14.27

--- a/stack-lts-16.31.yaml
+++ b/stack-lts-16.31.yaml
@@ -2,5 +2,7 @@ resolver: lts-16.31
 extra-deps:
   - aeson-1.5.2.0
   - envparse-0.4.1
-  - monad-logger-aeson-0.2.0.1
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3
   - context-0.2.0.0

--- a/stack-lts-16.31.yaml.lock
+++ b/stack-lts-16.31.yaml.lock
@@ -7,34 +7,48 @@ packages:
 - completed:
     hackage: aeson-1.5.2.0@sha256:d00c7aa51969b2849550e4dee14c9ce188504d55ed8d7f734ce9f6976db452f6,6786
     pantry-tree:
-      size: 39758
       sha256: 992b01282d72e4db664289db69a846a4ec675379ca96824ba902a7541104d409
+      size: 39758
   original:
     hackage: aeson-1.5.2.0
 - completed:
     hackage: envparse-0.4.1@sha256:989902e6368532548f61de1fa245ad2b39176cddd8743b20071af519a709ce30,2842
     pantry-tree:
-      size: 1180
       sha256: 35044d67979fe2a5cff05cf8736a06a265592433cdd03e13a72908ceed892612
+      size: 1180
   original:
     hackage: envparse-0.4.1
 - completed:
-    hackage: monad-logger-aeson-0.2.0.1@sha256:3ce33913e0f0f73cd272ce734abaae460bdbc48ad9c4d7192a912849060114b0,5156
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
     pantry-tree:
-      size: 5103
-      sha256: f221efc9a29a358c63b571cc3fb8e86cdcab3ee6aa29c8d4395ca85adb8fe2af
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
   original:
-    hackage: monad-logger-aeson-0.2.0.1
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 - completed:
     hackage: context-0.2.0.0@sha256:6b643adb4a64fe521873d08df0497f71f88e18b9ecff4b68b4eef938e446cfc9,1886
     pantry-tree:
-      size: 952
       sha256: b041ec197787d7cef078a2de33a74853179821e3083882f22b6d185e5764d75e
+      size: 952
   original:
     hackage: context-0.2.0.0
 snapshots:
 - completed:
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
     size: 534126
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
-    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
   original: lts-16.31

--- a/stack-lts-18.28.yaml
+++ b/stack-lts-18.28.yaml
@@ -1,4 +1,6 @@
 resolver: lts-18.28
 extra-deps:
-  - monad-logger-aeson-0.2.0.1
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3
   - context-0.2.0.0

--- a/stack-lts-18.28.yaml.lock
+++ b/stack-lts-18.28.yaml.lock
@@ -5,22 +5,36 @@
 
 packages:
 - completed:
-    hackage: monad-logger-aeson-0.2.0.1@sha256:3ce33913e0f0f73cd272ce734abaae460bdbc48ad9c4d7192a912849060114b0,5156
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
     pantry-tree:
-      size: 5103
-      sha256: f221efc9a29a358c63b571cc3fb8e86cdcab3ee6aa29c8d4395ca85adb8fe2af
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
   original:
-    hackage: monad-logger-aeson-0.2.0.1
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 - completed:
     hackage: context-0.2.0.0@sha256:6b643adb4a64fe521873d08df0497f71f88e18b9ecff4b68b4eef938e446cfc9,1886
     pantry-tree:
-      size: 952
       sha256: b041ec197787d7cef078a2de33a74853179821e3083882f22b6d185e5764d75e
+      size: 952
   original:
     hackage: context-0.2.0.0
 snapshots:
 - completed:
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
     size: 590100
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
   original: lts-18.28

--- a/stack-lts-19.33.yaml
+++ b/stack-lts-19.33.yaml
@@ -1,4 +1,6 @@
 resolver: lts-19.33
 extra-deps:
-  - monad-logger-aeson-0.4.0.2
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3
   - context-0.2.0.1

--- a/stack-lts-19.33.yaml.lock
+++ b/stack-lts-19.33.yaml.lock
@@ -5,12 +5,26 @@
 
 packages:
 - completed:
-    hackage: monad-logger-aeson-0.4.0.2@sha256:0a1189f53fdfa57e88735d0d65b943983010203fcd3f122ea552042dfb2d2501,6215
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
     pantry-tree:
-      sha256: 3955f99746fcb73d120b4bd486a110eec0bad975c00cc5ca29b3ba259c12a4b9
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
+  original:
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
       size: 7096
   original:
-    hackage: monad-logger-aeson-0.4.0.2
+    hackage: monad-logger-aeson-0.4.0.3
 - completed:
     hackage: context-0.2.0.1@sha256:b5a1390a5ad11b7edd0449c9ef96823f082bff4988bd09583e37a4e93e9aad10,1891
     pantry-tree:

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,1 +1,5 @@
 resolver: nightly-2022-12-08
+extra-deps:
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,5 +1,9 @@
-resolver: nightly-2022-12-08
+resolver: nightly-2024-05-28
 extra-deps:
   - fast-logger-3.2.3
   - monad-logger-0.3.39
   - monad-logger-aeson-0.4.0.3
+
+allow-newer: true
+allow-newer-deps:
+  - monad-logger-aeson

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,8 +1,6 @@
 resolver: nightly-2024-05-28
 extra-deps:
   - fast-logger-3.2.3
-  - monad-logger-0.3.39
-  - monad-logger-aeson-0.4.0.3
 
 allow-newer: true
 allow-newer-deps:

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -27,7 +27,7 @@ packages:
     hackage: monad-logger-aeson-0.4.0.3
 snapshots:
 - completed:
-    sha256: 0ce5b34f94d7dda9e8c00cc04aa4554818d293861038bbc83fbc8ffb7c7207b3
-    size: 558543
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/12/8.yaml
-  original: nightly-2022-12-08
+    sha256: 95b923f4f2efe2b6ba05c93ded367dfab81c545c0700731e5bef70bab03d9903
+    size: 644344
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/5/28.yaml
+  original: nightly-2024-05-28

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
+    pantry-tree:
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
+  original:
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 snapshots:
 - completed:
     sha256: 0ce5b34f94d7dda9e8c00cc04aa4554818d293861038bbc83fbc8ffb7c7207b3

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -11,20 +11,6 @@ packages:
       size: 1302
   original:
     hackage: fast-logger-3.2.3
-- completed:
-    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
-    pantry-tree:
-      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
-      size: 396
-  original:
-    hackage: monad-logger-0.3.39
-- completed:
-    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
-    pantry-tree:
-      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
-      size: 7096
-  original:
-    hackage: monad-logger-aeson-0.4.0.3
 snapshots:
 - completed:
     sha256: 95b923f4f2efe2b6ba05c93ded367dfab81c545c0700731e5bef70bab03d9903

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,7 @@ resolver: lts-20.3
 extra-deps:
   - fast-logger-3.2.3
   - monad-logger-0.3.39
-  - monad-logger-aeson-0.4.0.3
+
+allow-newer: true
+allow-newer-deps:
+  - monad-logger-aeson

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
 resolver: lts-20.3
+extra-deps:
+  - fast-logger-3.2.3
+  - monad-logger-0.3.39
+  - monad-logger-aeson-0.4.0.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,13 +18,6 @@ packages:
       size: 396
   original:
     hackage: monad-logger-0.3.39
-- completed:
-    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
-    pantry-tree:
-      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
-      size: 7096
-  original:
-    hackage: monad-logger-aeson-0.4.0.3
 snapshots:
 - completed:
     sha256: 03cec7d96ed78877b03b5c2bc5e31015b47f69af2fe6a62d994a42b7a43c5805

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: fast-logger-3.2.3@sha256:41b4f1c07d5ee4a7cc785689eb7772554d29ddbbcced3cc184fe50fc63ece3f7,2176
+    pantry-tree:
+      sha256: c4a8dcfa5f5bc3bd77cfe86d904e96f90607adc1e4f3f1cf082e722673ee7230
+      size: 1302
+  original:
+    hackage: fast-logger-3.2.3
+- completed:
+    hackage: monad-logger-0.3.39@sha256:edd49f160b77abe4883f0579839d30403cd425853ab83397abb44473ebc5445a,1759
+    pantry-tree:
+      sha256: 3c41320fd5a111cc02b13f1190bdb98b92cc270d7d52cfe5a85c667b08fbc528
+      size: 396
+  original:
+    hackage: monad-logger-0.3.39
+- completed:
+    hackage: monad-logger-aeson-0.4.0.3@sha256:1fc0f9f1f2dc8598c8f6f24625023b892a477cee3abaa67a4cc0e81b0dcdf6c6,6215
+    pantry-tree:
+      sha256: c2b3130a2326606a1087c8548c8f1682a299b554ffe84d9a460b7c382b3ebd84
+      size: 7096
+  original:
+    hackage: monad-logger-aeson-0.4.0.3
 snapshots:
 - completed:
     sha256: 03cec7d96ed78877b03b5c2bc5e31015b47f69af2fe6a62d994a42b7a43c5805


### PR DESCRIPTION
This version fixes the flush logging bug we were working around.

Fixes https://github.com/freckle/blammo/issues/41.