### PR TITLE
Add withLogger and generalized LoggingT'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: haskell/actions/hlint-setup@v2
-      - uses: haskell/actions/hlint-run@v2
+      - uses: haskell-actions/hlint-setup@v2
+      - uses: haskell-actions/hlint-run@v2
         with:
           fail-on: warning
           path: '["src/", "tests/"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         stack-yaml:
-          - stack-nightly.yaml   # ghc-9.4
-          - stack.yaml           # ghc-9.2
+          - stack-nightly.yaml # ghc-9.4
+          - stack.yaml # ghc-9.2
           - stack-lts-19.33.yaml # ghc-9.0
           - stack-lts-18.28.yaml # ghc-8.10
           - stack-lts-16.31.yaml # ghc-8.8
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: freckle/stack-action@v4
         with:
           stack-yaml: ${{ matrix.stack-yaml }}
@@ -30,7 +30,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell/actions/hlint-setup@v2
       - uses: haskell/actions/hlint-run@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,22 @@ on:
     branches: main
 
 jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: generate
+        uses: freckle/stack-action/generate-matrix@v5
+    outputs:
+      stack-yamls: ${{ steps.generate.outputs.stack-yamls }}
+
   test:
     runs-on: ubuntu-latest
+    needs: generate
 
     strategy:
       matrix:
-        stack-yaml:
-          - stack-nightly.yaml # ghc-9.4
-          - stack.yaml # ghc-9.2
-          - stack-lts-19.33.yaml # ghc-9.0
-          - stack-lts-18.28.yaml # ghc-8.10
-          - stack-lts-16.31.yaml # ghc-8.8
-          - stack-lts-14.27.yaml # ghc-8.6
-          - stack-lts-12.26.yaml # ghc-8.4
+        stack-yaml: ${{ fromJSON(needs.generate.outputs.stack-yamls) }}
       fail-fast: false
 
     steps:

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -52,6 +52,7 @@ library
       NoImplicitPrelude
       OverloadedStrings
       RecordWildCards
+      StandaloneDeriving
       TypeApplications
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:
@@ -99,6 +100,7 @@ test-suite readme
       NoImplicitPrelude
       OverloadedStrings
       RecordWildCards
+      StandaloneDeriving
       TypeApplications
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -pgmL markdown-unlit
   build-depends:
@@ -134,6 +136,7 @@ test-suite spec
       NoImplicitPrelude
       OverloadedStrings
       RecordWildCards
+      StandaloneDeriving
       TypeApplications
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -29,6 +29,7 @@ library
       Blammo.Logging.Colors
       Blammo.Logging.Internal.LogAction
       Blammo.Logging.Internal.Logger
+      Blammo.Logging.Internal.LoggerLogAction
       Blammo.Logging.Logger
       Blammo.Logging.LoggingT
       Blammo.Logging.LogSettings

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Blammo.Logging
       Blammo.Logging.Colors
+      Blammo.Logging.Internal.LogAction
       Blammo.Logging.Internal.Logger
       Blammo.Logging.Logger
       Blammo.Logging.LoggingT

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -29,6 +29,7 @@ library
       Blammo.Logging.Colors
       Blammo.Logging.Internal.Logger
       Blammo.Logging.Logger
+      Blammo.Logging.LoggingT
       Blammo.Logging.LogSettings
       Blammo.Logging.LogSettings.Env
       Blammo.Logging.LogSettings.LogLevels
@@ -64,10 +65,14 @@ library
     , fast-logger >=3.2.3
     , http-types
     , lens
+    , monad-control
     , monad-logger-aeson
     , mtl
+    , resourcet
     , text
     , time
+    , transformers
+    , transformers-base
     , unliftio
     , unliftio-core
     , unordered-containers

--- a/Blammo.cabal
+++ b/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        1.1.3.0
+version:        1.2.0.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [v1.2.0.0](https://github.com/freckle/blammo/compare/v1.1.3.0...v1.2.0.0)
 
-- Defined new `LoggerT` instead of re-exporting from the `monad-logger` package
+- Defined new `LoggerT` instead of re-exporting from the `monad-logger` package.
+  This `LoggerT` is now internally a `ReaderT` of our `Logger` type rather than
+  of a `monad-logger` log action `Loc -> LogSource -> LogLevel -> LogStr -> IO ()`,
+  which makes it a bit more powerful as the latter can be obtained from the former.
 
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v1.2.0.0](https://github.com/freckle/blammo/compare/v1.1.3.0...v1.2.0.0)
 
+- Add a new `withLogger` function that may serve as an alternative to
+  `newLogger` + `runLoggerLoggingT`.
 - Defined new `LoggerT` instead of re-exporting from the `monad-logger` package.
   This `LoggerT` is also a `ReaderT`-like newtype but based on our `Logger` type
   rather than rather than on a log action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v1.2.0.0](https://github.com/freckle/blammo/compare/v1.1.3.0...v1.2.0.0)
 
+- Defined new `LoggerT` instead of re-exporting from the `monad-logger` package
+
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 
 - Update fast-logger to fix log flushing bug, and remove 0.1s delay that was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.1.3.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/v1.2.0.0...main)
+
+## [v1.2.0.0](https://github.com/freckle/blammo/compare/v1.1.3.0...v1.2.0.0)
 
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
   `Logger`.
 - Added new `LoggerT'` which is a generalized variant of `LoggerT`; rather than
   being fixed to `Logger` as the reader context, it has a type parameter which
-  should be something with a `HasLogger` instance.
+  should be something with a `HasLogger` instance. Deriving via `LoggerT' app m`
+  can be a handy way to get an instance of `MonadLogger` for your application
+  monad.
 
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   `Loc -> LogSource -> LogLevel -> LogStr -> IO ()`,
   which makes it a bit more powerful, since the log can be obtained from the
   `Logger`.
+- Added new `LoggerT'` which is a generalized variant of `LoggerT`; rather than
+  being fixed to `Logger` as the reader context, it has a type parameter which
+  should be something with a `HasLogger` instance.
 
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [v1.2.0.0](https://github.com/freckle/blammo/compare/v1.1.3.0...v1.2.0.0)
 
 - Defined new `LoggerT` instead of re-exporting from the `monad-logger` package.
-  This `LoggerT` is now internally a `ReaderT` of our `Logger` type rather than
-  of a `monad-logger` log action `Loc -> LogSource -> LogLevel -> LogStr -> IO ()`,
-  which makes it a bit more powerful as the latter can be obtained from the former.
+  This `LoggerT` is also a `ReaderT`-like newtype but based on our `Logger` type
+  rather than rather than on a log action
+  `Loc -> LogSource -> LogLevel -> LogStr -> IO ()`,
+  which makes it a bit more powerful, since the log can be obtained from the
+  `Logger`.
 
 ## [v1.1.3.0](https://github.com/freckle/blammo/compare/v1.1.2.3...v1.1.3.0)
 

--- a/package.yaml
+++ b/package.yaml
@@ -54,10 +54,14 @@ library:
     - exceptions
     - fast-logger >= 3.2.3 # fix for bad flush behavior
     - lens
+    - monad-control
     - monad-logger-aeson
     - mtl
+    - resourcet
     - text
     - time
+    - transformers
+    - transformers-base
     - vector
     - unliftio
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 1.1.3.0
+version: 1.2.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/blammo

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings
   - RecordWildCards
+  - StandaloneDeriving
   - TypeApplications
 
 library:

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -58,10 +58,11 @@ import Prelude
 
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
+import Blammo.Logging.LoggingT
 import Control.Lens ((^.))
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Control.Monad.Logger.Aeson
+import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
 import Data.Aeson (Series)
 import Data.Aeson.Types (Pair)
 import Data.ByteString (ByteString)

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -56,6 +56,7 @@ module Blammo.Logging
 
 import Prelude
 
+import Blammo.Logging.Internal.LogAction
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Blammo.Logging.LoggingT
@@ -80,11 +81,9 @@ runLoggerLoggingT env f = (`finally` flushLogStr logger) $ do
 loggerOutput
   :: Logger
   -> (LogLevel -> ByteString -> ByteString)
-  -> Loc
-  -> LogSource
-  -> LogLevel
-  -> LogStr
-  -> IO ()
+  -> LogAction IO
 loggerOutput logger reformat =
-  defaultOutputWith $ defaultOutputOptions $ \logLevel bytes -> do
-    pushLogStrLn logger $ toLogStr $ reformat logLevel bytes
+  LogAction $
+    defaultOutputWith $
+      defaultOutputOptions $ \logLevel bytes -> do
+        pushLogStrLn logger $ toLogStr $ reformat logLevel bytes

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -33,6 +33,7 @@ module Blammo.Logging
   , MonadLogger (..)
   , MonadLoggerIO (..)
   , LoggingT
+  , LoggingT' (..)
 
     -- ** Common logging functions
 

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -56,7 +56,7 @@ module Blammo.Logging
 
 import Prelude
 
-import Blammo.Logging.Internal.LogAction
+import Blammo.Logging.Internal.LoggerLogAction (loggerLogAction)
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Blammo.Logging.LoggingT
@@ -73,13 +73,6 @@ runLoggerLoggingT
 runLoggerLoggingT env f = (`finally` flushLogStr logger) $ do
   runLoggingT
     (filterLogger (getLoggerShouldLog logger) f)
-    (loggerOutput logger)
+    (loggerLogAction logger)
  where
   logger = env ^. loggerL
-
-loggerOutput :: Logger -> LogAction IO
-loggerOutput logger =
-  LogAction $
-    defaultOutputWith $
-      defaultOutputOptions $ \logLevel bytes ->
-        pushLogStrLn logger $ toLogStr $ getLoggerReformat logger logLevel bytes

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -54,25 +54,10 @@ module Blammo.Logging
   , logOtherNS
   ) where
 
-import Prelude
-
-import Blammo.Logging.Internal.LoggerLogAction (loggerLogAction)
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Blammo.Logging.LoggingT
-import Control.Lens ((^.))
 import Control.Monad.Catch (MonadMask)
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
 import Data.Aeson (Series)
 import Data.Aeson.Types (Pair)
-import UnliftIO.Exception (finally)
-
-runLoggerLoggingT
-  :: (MonadUnliftIO m, HasLogger env) => env -> LoggingT m a -> m a
-runLoggerLoggingT env f = (`finally` flushLogStr logger) $ do
-  runLoggingT
-    (filterLogger (getLoggerShouldLog logger) f)
-    (loggerLogAction logger)
- where
-  logger = env ^. loggerL

--- a/src/Blammo/Logging.hs
+++ b/src/Blammo/Logging.hs
@@ -66,7 +66,6 @@ import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
 import Data.Aeson (Series)
 import Data.Aeson.Types (Pair)
-import Data.ByteString (ByteString)
 import UnliftIO.Exception (finally)
 
 runLoggerLoggingT
@@ -74,16 +73,13 @@ runLoggerLoggingT
 runLoggerLoggingT env f = (`finally` flushLogStr logger) $ do
   runLoggingT
     (filterLogger (getLoggerShouldLog logger) f)
-    (loggerOutput logger $ getLoggerReformat logger)
+    (loggerOutput logger)
  where
   logger = env ^. loggerL
 
-loggerOutput
-  :: Logger
-  -> (LogLevel -> ByteString -> ByteString)
-  -> LogAction IO
-loggerOutput logger reformat =
+loggerOutput :: Logger -> LogAction IO
+loggerOutput logger =
   LogAction $
     defaultOutputWith $
-      defaultOutputOptions $ \logLevel bytes -> do
-        pushLogStrLn logger $ toLogStr $ reformat logLevel bytes
+      defaultOutputOptions $ \logLevel bytes ->
+        pushLogStrLn logger $ toLogStr $ getLoggerReformat logger logLevel bytes

--- a/src/Blammo/Logging/Internal/LogAction.hs
+++ b/src/Blammo/Logging/Internal/LogAction.hs
@@ -1,0 +1,9 @@
+module Blammo.Logging.Internal.LogAction (LogAction (..), runLogAction) where
+
+import Control.Monad.Logger.Aeson hiding (LoggingT (..))
+
+newtype LogAction m = LogAction (Loc -> LogSource -> LogLevel -> LogStr -> m ())
+
+runLogAction
+  :: ToLogStr msg => LogAction m -> Loc -> LogSource -> LogLevel -> msg -> m ()
+runLogAction (LogAction f) loc source level msg = f loc source level (toLogStr msg)

--- a/src/Blammo/Logging/Internal/LoggerLogAction.hs
+++ b/src/Blammo/Logging/Internal/LoggerLogAction.hs
@@ -1,0 +1,15 @@
+module Blammo.Logging.Internal.LoggerLogAction (loggerLogAction) where
+
+import Prelude
+
+import Blammo.Logging.Internal.LogAction
+import Blammo.Logging.Logger
+import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
+
+loggerLogAction :: Logger -> LogAction IO
+loggerLogAction logger =
+  LogAction $
+    defaultOutputWith $
+      defaultOutputOptions $
+        \logLevel bytes ->
+          pushLogStrLn logger $ toLogStr $ getLoggerReformat logger logLevel bytes

--- a/src/Blammo/Logging/Internal/LoggerLogAction.hs
+++ b/src/Blammo/Logging/Internal/LoggerLogAction.hs
@@ -3,13 +3,17 @@ module Blammo.Logging.Internal.LoggerLogAction (loggerLogAction) where
 import Prelude
 
 import Blammo.Logging.Internal.LogAction
+import Blammo.Logging.Internal.Logger (Logger (..))
 import Blammo.Logging.Logger
+import Control.Monad (when)
 import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
 
 loggerLogAction :: Logger -> LogAction IO
 loggerLogAction logger =
-  LogAction $
-    defaultOutputWith $
-      defaultOutputOptions $
-        \logLevel bytes ->
-          pushLogStrLn logger $ toLogStr $ getLoggerReformat logger logLevel bytes
+  LogAction $ \loc source level msg ->
+    when (lShouldLog logger source level) $
+      defaultOutputWith options loc source level msg
+ where
+  options = defaultOutputOptions $
+    \logLevel bytes ->
+      pushLogStrLn logger $ toLogStr $ getLoggerReformat logger logLevel bytes

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -8,10 +9,15 @@ module Blammo.Logging.LoggingT (LoggingT, LoggingT' (..), runLoggerLoggingT) whe
 
 import Prelude
 
+#if MIN_VERSION_base(4, 19, 0)
+#else
+import Control.Applicative (Applicative (..))
+#endif
+
 import Blammo.Logging.Internal.LogAction
 import Blammo.Logging.Internal.LoggerLogAction (loggerLogAction)
 import Blammo.Logging.Logger
-import Control.Applicative (Alternative (..), Applicative (..))
+import Control.Applicative (Alternative (..))
 import Control.Lens ((^.))
 import Control.Monad.Base (MonadBase (..))
 import Control.Monad.Catch (MonadCatch (..), MonadMask (..), MonadThrow (..))

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Blammo.Logging.LoggingT (LoggingT (..), runLoggerLoggingT) where
+module Blammo.Logging.LoggingT (LoggingT, runLoggerLoggingT) where
 
 import Prelude
 
@@ -30,7 +30,9 @@ import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Resource (MonadResource (..))
 import UnliftIO.Exception (finally)
 
-newtype LoggingT m a = LoggingT {runLoggingT :: Logger -> m a}
+type LoggingT = LoggingT' Logger
+
+newtype LoggingT' env m a = LoggingT {runLoggingT :: env -> m a}
   deriving
     ( Functor
     , Applicative
@@ -44,39 +46,40 @@ newtype LoggingT m a = LoggingT {runLoggingT :: Logger -> m a}
     , MonadMask
     , MonadResource
     )
-    via ReaderT Logger m
+    via ReaderT env m
   deriving
     ( MonadTrans
     )
-    via ReaderT Logger
+    via ReaderT env
 
-instance MonadBase b m => MonadBase b (LoggingT m) where
+instance MonadBase b m => MonadBase b (LoggingT' env m) where
   liftBase = lift . liftBase
 
-instance MonadTransControl LoggingT where
-  type StT LoggingT a = a
+instance MonadTransControl (LoggingT' env) where
+  type StT (LoggingT' env) a = a
   liftWith f = LoggingT $ \r -> f $ \(LoggingT t) -> t r
   restoreT = LoggingT . const
 
-instance MonadBaseControl b m => MonadBaseControl b (LoggingT m) where
-  type StM (LoggingT m) a = StM m a
+instance MonadBaseControl b m => MonadBaseControl b (LoggingT' env m) where
+  type StM (LoggingT' env m) a = StM m a
   liftBaseWith f = LoggingT $ \reader' ->
     liftBaseWith $ \runInBase ->
       f $ runInBase . (\(LoggingT r) -> r reader')
   restoreM = LoggingT . const . restoreM
 
-instance MonadIO m => MonadLogger (LoggingT m) where
-  monadLoggerLog a b c d = LoggingT $ \logger ->
+instance (MonadIO m, HasLogger env) => MonadLogger (LoggingT' env m) where
+  monadLoggerLog a b c d = do
+    logger <- getLogger
     liftIO $ runLogAction (loggerLogAction logger) a b c d
 
-instance MonadIO m => MonadLoggerIO (LoggingT m) where
-  askLoggerIO = LoggingT $ \logger ->
-    pure $ runLogAction $ loggerLogAction logger
+instance (MonadIO m, HasLogger env) => MonadLoggerIO (LoggingT' env m) where
+  askLoggerIO =
+    runLogAction . loggerLogAction <$> getLogger
 
-instance (Applicative m, Semigroup a) => Semigroup (LoggingT m a) where
+instance (Applicative m, Semigroup a) => Semigroup (LoggingT' env m a) where
   (<>) = liftA2 (<>)
 
-instance (Applicative m, Monoid a) => Monoid (LoggingT m a) where
+instance (Applicative m, Monoid a) => Monoid (LoggingT' env m a) where
   mempty = pure mempty
 
 runLoggerLoggingT
@@ -85,3 +88,6 @@ runLoggerLoggingT env f =
   runLoggingT f logger `finally` flushLogStr logger
  where
   logger = env ^. loggerL
+
+getLogger :: (Applicative m, HasLogger env) => LoggingT' env m Logger
+getLogger = LoggingT $ pure . (^. loggerL)

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Blammo.Logging.LoggingT (LoggingT, runLoggerLoggingT) where
+module Blammo.Logging.LoggingT (LoggingT, LoggingT' (..), runLoggerLoggingT) where
 
 import Prelude
 

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -10,6 +10,13 @@ module Blammo.Logging.LoggingT (LoggingT, LoggingT' (..), runLoggerLoggingT) whe
 
 import Prelude
 
+#if MIN_VERSION_base(4, 13, 0)
+#else
+#if MIN_VERSION_base(4, 9, 0)
+import Control.Monad.Fail (MonadFail (..))
+#endif
+#endif
+
 #if MIN_VERSION_base(4, 19, 0)
 #else
 import Control.Applicative (Applicative (..))
@@ -45,7 +52,6 @@ newtype LoggingT' env m a = LoggingT {runLoggingT :: env -> m a}
     , Applicative
     , Alternative
     , Monad
-    , MonadFail
     , MonadIO
     , MonadThrow
     , MonadCatch
@@ -57,6 +63,11 @@ newtype LoggingT' env m a = LoggingT {runLoggingT :: env -> m a}
     ( MonadTrans
     )
     via ReaderT env
+
+#if MIN_VERSION_base(4, 9, 0)
+deriving via ReaderT env m
+  instance MonadFail m => MonadFail (LoggingT' env m)
+#endif
 
 #if MIN_VERSION_unliftio_core(0, 2, 0)
 deriving via (ReaderT env m)

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Blammo.Logging.LoggingT (LoggingT (..), filterLogger) where
+
+import Prelude
+
+import Control.Applicative (Alternative (..), Applicative (..))
+import Control.Monad (when)
+import Control.Monad.Base (MonadBase (..))
+import Control.Monad.Catch (MonadCatch (..), MonadMask (..), MonadThrow (..))
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Unlift (MonadUnliftIO (..))
+import Control.Monad.Logger.Aeson hiding (LoggingT (..), filterLogger)
+import Control.Monad.Trans.Class (MonadTrans (..))
+import Control.Monad.Trans.Control
+  ( MonadBaseControl (..)
+  , MonadTransControl (..)
+  )
+import Control.Monad.Trans.Resource (MonadResource (..))
+
+newtype LoggingT m a = LoggingT
+  {runLoggingT :: (Loc -> LogSource -> LogLevel -> LogStr -> IO ()) -> m a}
+instance Functor m => Functor (LoggingT m) where
+  fmap f logger = LoggingT (fmap f . runLoggingT logger)
+
+instance Applicative m => Applicative (LoggingT m) where
+  pure = LoggingT . const . pure
+  loggerF <*> loggerA = LoggingT $ \loggerFn ->
+    runLoggingT loggerF loggerFn
+      <*> runLoggingT loggerA loggerFn
+
+instance Alternative m => Alternative (LoggingT m) where
+  empty = LoggingT (const empty)
+  LoggingT x <|> LoggingT y = LoggingT (\f -> x f <|> y f)
+
+instance Monad m => Monad (LoggingT m) where
+  LoggingT ma >>= f = LoggingT $ \r -> do
+    a <- ma r
+    let LoggingT f' = f a
+    f' r
+
+instance MonadIO m => MonadIO (LoggingT m) where
+  liftIO = lift . liftIO
+
+instance MonadThrow m => MonadThrow (LoggingT m) where
+  throwM = lift . throwM
+
+instance MonadCatch m => MonadCatch (LoggingT m) where
+  catch (LoggingT m) c =
+    LoggingT $ \r -> m r `catch` \e -> runLoggingT (c e) r
+
+instance MonadMask m => MonadMask (LoggingT m) where
+  mask a = LoggingT $ \e -> mask $ \u -> runLoggingT (a $ q u) e
+   where
+    q u (LoggingT b) = LoggingT (u . b)
+  uninterruptibleMask a =
+    LoggingT $ \e -> uninterruptibleMask $ \u -> runLoggingT (a $ q u) e
+   where
+    q u (LoggingT b) = LoggingT (u . b)
+  generalBracket acquire release use =
+    LoggingT $ \e ->
+      generalBracket
+        (runLoggingT acquire e)
+        (\x ec -> runLoggingT (release x ec) e)
+        (\x -> runLoggingT (use x) e)
+
+instance MonadResource m => MonadResource (LoggingT m) where
+  liftResourceT = lift . liftResourceT
+
+instance MonadBase b m => MonadBase b (LoggingT m) where
+  liftBase = lift . liftBase
+
+instance MonadTrans LoggingT where
+  lift = LoggingT . const
+
+instance MonadTransControl LoggingT where
+  type StT LoggingT a = a
+  liftWith f = LoggingT $ \r -> f $ \(LoggingT t) -> t r
+  restoreT = LoggingT . const
+
+instance MonadBaseControl b m => MonadBaseControl b (LoggingT m) where
+  type StM (LoggingT m) a = StM m a
+  liftBaseWith f = LoggingT $ \reader' ->
+    liftBaseWith $ \runInBase ->
+      f $ runInBase . (\(LoggingT r) -> r reader')
+  restoreM = LoggingT . const . restoreM
+
+instance MonadIO m => MonadLogger (LoggingT m) where
+  monadLoggerLog a b c d = LoggingT $ \f -> liftIO $ f a b c (toLogStr d)
+
+instance MonadIO m => MonadLoggerIO (LoggingT m) where
+  askLoggerIO = LoggingT return
+
+instance MonadUnliftIO m => MonadUnliftIO (LoggingT m) where
+  withRunInIO inner =
+    LoggingT $ \r ->
+      withRunInIO $ \run ->
+        inner (run . flip runLoggingT r)
+
+instance (Applicative m, Semigroup a) => Semigroup (LoggingT m a) where
+  (<>) = liftA2 (<>)
+
+instance (Applicative m, Monoid a) => Monoid (LoggingT m a) where
+  mempty = pure mempty
+
+-- | Only log messages passing the given predicate function
+--
+-- This can be a convenient way, for example, to ignore debug level messages.
+filterLogger
+  :: (LogSource -> LogLevel -> Bool)
+  -> LoggingT m a
+  -> LoggingT m a
+filterLogger p (LoggingT f) = LoggingT $ \logger ->
+  f $ \loc src level msg ->
+    when (p src level) $ logger loc src level msg

--- a/src/Blammo/Logging/LoggingT.hs
+++ b/src/Blammo/Logging/LoggingT.hs
@@ -18,14 +18,14 @@ import Control.Monad.Fail (MonadFail (..))
 #endif
 
 #if MIN_VERSION_base(4, 19, 0)
+import Control.Applicative (Alternative (..))
 #else
-import Control.Applicative (Applicative (..))
+import Control.Applicative (Alternative (..), Applicative (..))
 #endif
 
 import Blammo.Logging.Internal.LogAction
 import Blammo.Logging.Internal.LoggerLogAction (loggerLogAction)
 import Blammo.Logging.Logger
-import Control.Applicative (Alternative (..))
 import Control.Lens ((^.))
 import Control.Monad.Base (MonadBase (..))
 import Control.Monad.Catch (MonadCatch (..), MonadMask (..), MonadThrow (..))

--- a/stack-lts-13.0.yaml
+++ b/stack-lts-13.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.26
+resolver: lts-13.0
 extra-deps:
   - envparse-0.5.0
   - fast-logger-3.2.3

--- a/stack-lts-13.0.yaml.lock
+++ b/stack-lts-13.0.yaml.lock
@@ -75,9 +75,9 @@ packages:
   original:
     hackage: hspec-2.7.9
 - completed:
-    hackage: hspec-core-2.7.9@sha256:5153ef21166ad380abf800cae27a3956ed5409bf1a1f1b58356733747a03bff5,4730
+    hackage: hspec-core-2.7.9@sha256:c17d18974f057edb662dca266cc114c0650f1d5674e0ddc65969137e92feb946,4748
     pantry-tree:
-      sha256: f07977ee2b6f33671b4fa993f579179f2b07b78a4d8cd2a1989b537afaeb0360
+      sha256: c510d5513116c815a5a675eb09e8d1ad79e8efcd8d482bfd3734335b35499e04
       size: 3886
   original:
     hackage: hspec-core-2.7.9
@@ -89,9 +89,9 @@ packages:
   original:
     hackage: hspec-discover-2.7.9
 - completed:
-    hackage: primitive-0.7.4.0@sha256:89b88a3e08493b7727fa4089b0692bfbdf7e1e666ef54635f458644eb8358764,2857
+    hackage: primitive-0.7.4.0@sha256:c2f0ed97b3dce97f2f43b239c3be8b136e4368f1eb7b61322ee9ac98f604622b,2982
     pantry-tree:
-      sha256: 71a850c658b70e869da19f61615d87d9d6ecec597f0e3d4b498da56559114829
+      sha256: 1cd1f40729b3038f1140fbf506ce59ab2db3f745b1727e0beba6390621aa9630
       size: 1655
   original:
     hackage: primitive-0.7.4.0
@@ -146,7 +146,7 @@ packages:
     hackage: vector-algorithms-0.8.0.1
 snapshots:
 - completed:
-    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
-    size: 509471
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/12/26.yaml
-  original: lts-12.26
+    sha256: 8d3c33e0feab8e04b9ed31452e0219a2b827ed1338c809f79d986c71a177e6ba
+    size: 491155
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/0.yaml
+  original: lts-13.0


### PR DESCRIPTION
This is technically a breaking change, though not breaking for any of our apps.

This change allows "application monads" (such as `AppT` and `AppExample` in `freckle-app`) to remove `LoggingT` from their monad stack. Instead, they can derive `MonadLogger` via `LoggingT' app m`, when the constraint `HasLogger app` is satisfied. (I've tried this in `freckle-app` and confirmed it works.)

`LoggingT'` is like `LoggingT` but the reader context is generalized from `Logger` to `HasLogger env => env`. `LoggingT` is just a type alias for `LoggingT' Logger` for compatibility. It would look nicer if we just call the more generic one `LoggingT` and remove the specialized type alias, but leaving it this way makes upgrading smoother.

A new function `withLogger` is provided, which will be used instead of `runLoggerLoggingT` to wrap the setup and teardown of an app. Typical usage looks like:

```haskell
withApp continue = do
  loggingSettings <- _
  withLogger loggingSettings $ \logger -> do
    _
    continue App{logger, ..}
```