### PR TITLE
Don't log invalid details about a raw response

### DIFF
--- a/Blammo-wai/Blammo-wai.cabal
+++ b/Blammo-wai/Blammo-wai.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo-wai
-version:        0.0.0.0
+version:        0.0.0.1
 synopsis:       Using Blammo with WAI
 description:    Please see README.md
 category:       Logging, Web

--- a/Blammo-wai/Blammo-wai.cabal
+++ b/Blammo-wai/Blammo-wai.cabal
@@ -47,6 +47,7 @@ library
     , case-insensitive
     , clock
     , http-types
+    , monad-logger-aeson
     , text
     , unliftio-core
     , wai

--- a/Blammo-wai/CHANGELOG.md
+++ b/Blammo-wai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.0.0.1](https://github.com/freckle/blammo/compare/Blammo-wai-v0.0.0.0...Blammo-wai-v0.0.0.1)
 
-...
+- Don't show invalid details when logging raw responses
 
 ## [v0.0.0.0](https://github.com/freckle/blammo/tree/Blammo-wai-v0.0.0.0/Blammo-wai)
 

--- a/Blammo-wai/package.yaml
+++ b/Blammo-wai/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo-wai
-version: 0.0.0.0
+version: 0.0.0.1
 maintainer: Freckle Education
 category: Logging, Web
 github: freckle/blammo

--- a/Blammo-wai/package.yaml
+++ b/Blammo-wai/package.yaml
@@ -53,6 +53,7 @@ library:
     - case-insensitive
     - clock
     - http-types
+    - monad-logger-aeson
     - text
     - unliftio-core
     - wai

--- a/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
+++ b/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
@@ -155,8 +155,10 @@ requestLoggerWith config env app req respond =
   getTime = Clock.getTime Clock.Monotonic
   toMillis x = fromIntegral (Clock.toNanoSecs x) / nsPerMs
   isRaw = \case
+    ResponseFile {} -> False
+    ResponseBuilder {} -> False
+    ResponseStream {} -> False
     ResponseRaw {} -> True
-    _ -> False
 
 logRawResponse :: MonadLogger m => Config -> Double -> Request -> m ()
 logRawResponse config@Config {..} duration req =

--- a/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
+++ b/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
@@ -18,6 +18,7 @@ import Blammo.Logging
 import Control.Applicative ((<|>))
 import Control.Arrow ((***))
 import Control.Monad.IO.Unlift (withRunInIO)
+import Control.Monad.Logger.Aeson (SeriesElem)
 import Data.Aeson
 import qualified Data.Aeson.Compat as Key
 import qualified Data.Aeson.Compat as KeyMap
@@ -187,7 +188,7 @@ requestMessage req suffix =
     <> " => "
     <> suffix
 
-requestDetails :: KeyValue a => Config -> Request -> [a]
+requestDetails :: Config -> Request -> [SeriesElem]
 requestDetails Config {..} req =
   [ "method" .= decodeUtf8 (requestMethod req)
   , "path" .= decodeUtf8 (rawPathInfo req)
@@ -198,7 +199,7 @@ requestDetails Config {..} req =
       .= headerObject ["authorization", "cookie"] (requestHeaders req)
   ]
 
-responseDetails :: KeyValue a => Response -> [a]
+responseDetails :: Response -> [SeriesElem]
 responseDetails resp =
   [ "status"
       .= object


### PR DESCRIPTION
`wai` has a `RawResponse` constructor for `Response`[^1]. This is used
by applications that need to send raw bytes on the wire, such as
WebSockets.

This constructor has a field that is also type `Response`; functions
such as `responseStatus`[^2] or `responseHeaders` ultimately read from
this value since there is no actual status or headers that we can access
in the "raw" response itself.

This is an obvious but bad thing to do in something like `requestLogger`
because this inner response means nothing about what is actually
happening. It's there as a "fallback" to be used when raw responses
aren't supported. So it's almost always some kind of 500 error
response[^3]. Ultimately, this causes any Blammo-using applications to
report every WebSockets response as a 500 in the logs.

By its nature, there's not much we can do instead, as we know nothing
about the response, so this commit just changes things to omit response
details entirely for such cases. This is the approach taken by the more
official `Network.Wai.Middleware.RequestLogger` too[^4].

---

I included a follow-up refactor separately, to (hopefully) make review
easier, but I plan to squash that in before merge.

[^1]: https://hackage.haskell.org/package/wai-3.2.4/docs/src/Network.Wai.Internal.html#Response
[^2]: https://hackage.haskell.org/package/wai-3.2.4/docs/src/Network.Wai.html#responseStatus
[^3]: https://hackage.haskell.org/package/yesod-core-1.6.26.0/docs/src/Yesod.Core.Handler.html#sendRawResponseNoConduit
[^4]: https://hackage.haskell.org/package/wai-extra-3.1.15/docs/src/Network.Wai.Middleware.RequestLogger.html#detailedMiddleware%27