### PR TITLE
Remove some lesser-used reexports from Blammo.Logging

### DIFF
--- a/Blammo-wai/Blammo-wai.cabal
+++ b/Blammo-wai/Blammo-wai.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo-wai
-version:        0.0.0.1
+version:        0.0.0.2
 synopsis:       Using Blammo with WAI
 description:    Please see README.md
 category:       Logging, Web

--- a/Blammo-wai/CHANGELOG.md
+++ b/Blammo-wai/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-wai-v0.0.0.1..main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-wai-v0.0.0.2..main)
+
+## [v0.0.0.2](https://github.com/freckle/blammo/compare/Blammo-wai-v0.0.0.1...Blammo-wai-v0.0.0.2)
+
+- Support `Blammo-2.1.0.0`
 
 ## [v0.0.0.1](https://github.com/freckle/blammo/compare/Blammo-wai-v0.0.0.0...Blammo-wai-v0.0.0.1)
 

--- a/Blammo-wai/README.lhs
+++ b/Blammo-wai/README.lhs
@@ -27,7 +27,7 @@ import Control.Lens (lens)
 
 ```haskell
 -- Blammo
-import Blammo.Logging
+import Blammo.Logging.Simple
 
 -- wai
 import Network.Wai (Middleware)

--- a/Blammo-wai/package.yaml
+++ b/Blammo-wai/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo-wai
-version: 0.0.0.1
+version: 0.0.0.2
 maintainer: Freckle Education
 category: Logging, Web
 github: freckle/blammo

--- a/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
+++ b/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
@@ -15,6 +15,7 @@ module Network.Wai.Middleware.Logging
 import Prelude
 
 import Blammo.Logging
+import Blammo.Logging.ThreadContext
 import Control.Applicative ((<|>))
 import Control.Arrow ((***))
 import Control.Monad.IO.Unlift (withRunInIO)

--- a/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
+++ b/Blammo-wai/src/Network/Wai/Middleware/Logging.hs
@@ -15,7 +15,8 @@ module Network.Wai.Middleware.Logging
 import Prelude
 
 import Blammo.Logging
-import Blammo.Logging.ThreadContext
+import Blammo.Logging.Setup (HasLogger, runWithLogger)
+import Blammo.Logging.ThreadContext (Pair, withThreadContext)
 import Control.Applicative ((<|>))
 import Control.Arrow ((***))
 import Control.Monad.IO.Unlift (withRunInIO)

--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        2.0.0.0
+version:        2.1.0.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Logging
@@ -36,6 +36,7 @@ library
       Blammo.Logging.Terminal
       Blammo.Logging.Terminal.LogPiece
       Blammo.Logging.Test
+      Blammo.Logging.ThreadContext
       Blammo.Logging.WithLogger
       Data.Aeson.Compat
       System.Log.FastLogger.Compat

--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -32,6 +32,7 @@ library
       Blammo.Logging.LogSettings
       Blammo.Logging.LogSettings.Env
       Blammo.Logging.LogSettings.LogLevels
+      Blammo.Logging.Setup
       Blammo.Logging.Simple
       Blammo.Logging.Terminal
       Blammo.Logging.Terminal.LogPiece

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.0.0.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.2.0.0...main)
+
+## [v2.1.0.0](https://github.com/freckle/blammo/compare/v2.0.0.0...Blammo-v2.1.0.0)
+
+- Moved `MonadMask`, `withThreadContext`, `myThreadContext`, `Pair` from
+  `Blammo.Logging` to `Blammo.Logging.ThreadContext`.
 
 ## [v2.0.0.0](https://github.com/freckle/blammo/compare/v1.2.1.0...Blammo-v2.0.0.0)
 

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [v2.1.0.0](https://github.com/freckle/blammo/compare/v2.0.0.0...Blammo-v2.1.0.0)
 
-- Moved `MonadMask`, `withThreadContext`, `myThreadContext`, `Pair` from
-  `Blammo.Logging` to `Blammo.Logging.ThreadContext`.
+Removes less frequently used definitions from the main `Blammo.Logging` module
+into other modules.
+
+- Moved from `Blammo.Logging` to new module `Blammo.Logging.ThreadContext`:
+  `MonadMask`, `withThreadContext`, `myThreadContext`, `Pair`.
+- Removed from `Blammo.Logging` (still available in `Blammo.Logging.LogSettings`):
+  `LogSettings`, `LogDestination (..)`, `LogFormat (..)`, `defaultLogSettings`,
+  `LogColor (..)`, `setLogSettingsLevels`, `setLogSettingsDestination`,
+  `setLogSettingsFormat`, `setLogSettingsColor`, `setLogSettingsBreakpoint`,
+  `setLogSettingsConcurrency`.
 
 ## [v2.0.0.0](https://github.com/freckle/blammo/compare/v1.2.1.0...Blammo-v2.0.0.0)
 

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -13,6 +13,11 @@ into other modules.
   `setLogSettingsFormat`, `setLogSettingsColor`, `setLogSettingsBreakpoint`,
   `setLogSettingsConcurrency`.
 
+`Blammo.Logging.Simple` has been expanded to include reëxports of:
+
+- `Blammo.Logging.LogSettings`
+- `Blammo.Logging.ThreadContext`
+
 ## [v2.0.0.0](https://github.com/freckle/blammo/compare/v1.2.1.0...Blammo-v2.0.0.0)
 
 - Remove module `Network.Wai.Middleware.Logging`. It is moved to a new

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -12,10 +12,14 @@ into other modules.
   `LogColor (..)`, `setLogSettingsLevels`, `setLogSettingsDestination`,
   `setLogSettingsFormat`, `setLogSettingsColor`, `setLogSettingsBreakpoint`,
   `setLogSettingsConcurrency`.
+- Moved from `Blammo.Logging` to new module `Blammo.Logging.Setup`:
+  `HasLogger (..)`, `withLogger`, `newLogger`, `runLoggerLoggingT`, `LoggingT`,
+  `WithLogger (..)`, `runWithLogger`
 
 `Blammo.Logging.Simple` has been expanded to include reëxports of:
 
 - `Blammo.Logging.LogSettings`
+- `Blammo.Logging.Setup`
 - `Blammo.Logging.ThreadContext`
 
 ## [v2.0.0.0](https://github.com/freckle/blammo/compare/v1.2.1.0...Blammo-v2.0.0.0)

--- a/Blammo/README.lhs
+++ b/Blammo/README.lhs
@@ -44,8 +44,6 @@ import Control.Monad.Reader (MonadReader, ReaderT (runReaderT))
 
 ```haskell
 import Blammo.Logging.Simple
-import Blammo.Logging.LogSettings
-import Blammo.Logging.ThreadContext
 ```
 
 Throughout your application, you should write against the ubiquitous

--- a/Blammo/README.lhs
+++ b/Blammo/README.lhs
@@ -44,6 +44,7 @@ import Control.Monad.Reader (MonadReader, ReaderT (runReaderT))
 
 ```haskell
 import Blammo.Logging.Simple
+import Blammo.Logging.LogSettings
 import Blammo.Logging.ThreadContext
 ```
 

--- a/Blammo/README.lhs
+++ b/Blammo/README.lhs
@@ -44,6 +44,7 @@ import Control.Monad.Reader (MonadReader, ReaderT (runReaderT))
 
 ```haskell
 import Blammo.Logging.Simple
+import Blammo.Logging.ThreadContext
 ```
 
 Throughout your application, you should write against the ubiquitous

--- a/Blammo/package.yaml
+++ b/Blammo/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 2.0.0.0
+version: 2.1.0.0
 maintainer: Freckle Education
 category: Logging
 github: freckle/blammo

--- a/Blammo/src/Blammo/Logging.hs
+++ b/Blammo/src/Blammo/Logging.hs
@@ -24,12 +24,6 @@ module Blammo.Logging
   , (.=)
   , Series
 
-    -- ** Thread Context
-  , MonadMask
-  , withThreadContext
-  , myThreadContext
-  , Pair
-
     -- ** Transformers
   , MonadLogger (..)
   , MonadLoggerIO (..)
@@ -61,11 +55,9 @@ import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Blammo.Logging.WithLogger
 import Control.Lens (view)
-import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger.Aeson
 import Data.Aeson (Series)
-import Data.Aeson.Types (Pair)
 import UnliftIO.Exception (finally)
 
 -- | Initialize logging, pass a 'Logger' to the callback, and clean up at the end

--- a/Blammo/src/Blammo/Logging.hs
+++ b/Blammo/src/Blammo/Logging.hs
@@ -1,16 +1,5 @@
 module Blammo.Logging
-  ( LogSettings
-  , LogLevel (..)
-  , LogDestination (..)
-  , LogFormat (..)
-  , LogColor (..)
-  , defaultLogSettings
-  , setLogSettingsLevels
-  , setLogSettingsDestination
-  , setLogSettingsFormat
-  , setLogSettingsColor
-  , setLogSettingsBreakpoint
-  , setLogSettingsConcurrency
+  ( LogLevel (..)
   , Logger
   , HasLogger (..)
   , withLogger
@@ -51,7 +40,6 @@ module Blammo.Logging
   , logOtherNS
   ) where
 
-import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Blammo.Logging.WithLogger
 import Control.Lens (view)

--- a/Blammo/src/Blammo/Logging.hs
+++ b/Blammo/src/Blammo/Logging.hs
@@ -1,10 +1,6 @@
 module Blammo.Logging
   ( LogLevel (..)
   , Logger
-  , HasLogger (..)
-  , withLogger
-  , newLogger
-  , runLoggerLoggingT
 
     -- * Re-exports from "Control.Monad.Logger.Aeson"
 
@@ -13,12 +9,9 @@ module Blammo.Logging
   , (.=)
   , Series
 
-    -- ** Transformers
+    -- ** Classes
   , MonadLogger (..)
   , MonadLoggerIO (..)
-  , LoggingT
-  , WithLogger (..)
-  , runWithLogger
 
     -- ** Common logging functions
 
@@ -41,19 +34,5 @@ module Blammo.Logging
   ) where
 
 import Blammo.Logging.Logger
-import Blammo.Logging.WithLogger
-import Control.Lens (view)
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger.Aeson
 import Data.Aeson (Series)
-import UnliftIO.Exception (finally)
-
--- | Initialize logging, pass a 'Logger' to the callback, and clean up at the end
---
--- Applications should avoid calling this more than once in their lifecycle.
-runLoggerLoggingT
-  :: (MonadUnliftIO m, HasLogger env) => env -> LoggingT m a -> m a
-runLoggerLoggingT env f =
-  runLoggingT f (runLogAction logger) `finally` flushLogStr logger
- where
-  logger = view loggerL env

--- a/Blammo/src/Blammo/Logging/Setup.hs
+++ b/Blammo/src/Blammo/Logging/Setup.hs
@@ -1,0 +1,51 @@
+module Blammo.Logging.Setup
+  ( HasLogger (..)
+  , withLogger
+  , newLogger
+  , runLoggerLoggingT
+  , LoggingT
+  , WithLogger (..)
+  , runWithLogger
+  , newLoggerEnv
+  , withLoggerEnv
+  , runSimpleLoggingT
+  ) where
+
+import Prelude
+
+import Blammo.Logging
+import qualified Blammo.Logging.LogSettings.Env as Env
+import Blammo.Logging.Logger
+import Blammo.Logging.WithLogger
+import Control.Lens (view)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Logger.Aeson
+import UnliftIO.Exception (finally)
+
+-- | Construct a 'Logger' configured via environment variables
+newLoggerEnv :: MonadIO m => m Logger
+newLoggerEnv = liftIO $ newLogger =<< Env.parse
+
+-- | Initialize logging (configured via environment variables),
+--   pass a 'Logger' to the callback, and clean up at the end
+--
+-- Applications should avoid calling this more than once in their lifecycle.
+withLoggerEnv :: MonadUnliftIO m => (Logger -> m a) -> m a
+withLoggerEnv f = liftIO Env.parse >>= \logger -> withLogger logger f
+
+-- | Construct a 'Logger' configured via environment variables and use it
+runSimpleLoggingT :: MonadUnliftIO m => LoggingT m a -> m a
+runSimpleLoggingT f = do
+  logger <- newLoggerEnv
+  runLoggerLoggingT logger f
+
+-- | Initialize logging, pass a 'Logger' to the callback, and clean up at the end
+--
+-- Applications should avoid calling this more than once in their lifecycle.
+runLoggerLoggingT
+  :: (MonadUnliftIO m, HasLogger env) => env -> LoggingT m a -> m a
+runLoggerLoggingT env f =
+  runLoggingT f (runLogAction logger) `finally` flushLogStr logger
+ where
+  logger = view loggerL env

--- a/Blammo/src/Blammo/Logging/Simple.hs
+++ b/Blammo/src/Blammo/Logging/Simple.hs
@@ -1,35 +1,12 @@
 -- | Simplified out-of-the-box logging
 module Blammo.Logging.Simple
-  ( newLoggerEnv
-  , withLoggerEnv
-  , runSimpleLoggingT
-  , module Blammo.Logging
+  ( module Blammo.Logging
   , module Blammo.Logging.LogSettings
   , module Blammo.Logging.ThreadContext
+  , module Blammo.Logging.Setup
   ) where
 
-import Prelude
-
 import Blammo.Logging
-import qualified Blammo.Logging.LogSettings.Env as Env
-import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Blammo.Logging.LogSettings
+import Blammo.Logging.Setup
 import Blammo.Logging.ThreadContext
-
--- | Construct a 'Logger' configured via environment variables
-newLoggerEnv :: MonadIO m => m Logger
-newLoggerEnv = liftIO $ newLogger =<< Env.parse
-
--- | Initialize logging (configured via environment variables),
---   pass a 'Logger' to the callback, and clean up at the end
---
--- Applications should avoid calling this more than once in their lifecycle.
-withLoggerEnv :: MonadUnliftIO m => (Logger -> m a) -> m a
-withLoggerEnv f = liftIO Env.parse >>= \logger -> withLogger logger f
-
--- | Construct a 'Logger' configured via environment variables and use it
-runSimpleLoggingT :: MonadUnliftIO m => LoggingT m a -> m a
-runSimpleLoggingT f = do
-  logger <- newLoggerEnv
-  runLoggerLoggingT logger f

--- a/Blammo/src/Blammo/Logging/Simple.hs
+++ b/Blammo/src/Blammo/Logging/Simple.hs
@@ -4,6 +4,8 @@ module Blammo.Logging.Simple
   , withLoggerEnv
   , runSimpleLoggingT
   , module Blammo.Logging
+  , module Blammo.Logging.LogSettings
+  , module Blammo.Logging.ThreadContext
   ) where
 
 import Prelude
@@ -12,6 +14,8 @@ import Blammo.Logging
 import qualified Blammo.Logging.LogSettings.Env as Env
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Blammo.Logging.LogSettings
+import Blammo.Logging.ThreadContext
 
 -- | Construct a 'Logger' configured via environment variables
 newLoggerEnv :: MonadIO m => m Logger

--- a/Blammo/src/Blammo/Logging/ThreadContext.hs
+++ b/Blammo/src/Blammo/Logging/ThreadContext.hs
@@ -1,0 +1,10 @@
+module Blammo.Logging.ThreadContext
+  ( MonadMask
+  , withThreadContext
+  , myThreadContext
+  , Pair
+  ) where
+
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.Logger.Aeson (myThreadContext, withThreadContext)
+import Data.Aeson.Types (Pair)

--- a/Blammo/tests/Blammo/Logging/LoggerSpec.hs
+++ b/Blammo/tests/Blammo/Logging/LoggerSpec.hs
@@ -7,6 +7,7 @@ module Blammo.Logging.LoggerSpec
 import Prelude
 
 import Blammo.Logging
+import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (Value (..))

--- a/Blammo/tests/Blammo/Logging/LoggerSpec.hs
+++ b/Blammo/tests/Blammo/Logging/LoggerSpec.hs
@@ -6,9 +6,8 @@ module Blammo.Logging.LoggerSpec
 
 import Prelude
 
-import Blammo.Logging
-import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
+import Blammo.Logging.Simple
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (Value (..))
 import qualified Data.Aeson.Compat as KeyMap

--- a/Blammo/tests/Blammo/Logging/TerminalSpec.hs
+++ b/Blammo/tests/Blammo/Logging/TerminalSpec.hs
@@ -9,7 +9,8 @@ import Prelude
 import Blammo.Logging
 import Blammo.Logging.Logger (LoggedMessage (..))
 import Blammo.Logging.Terminal
-import Data.Aeson
+import Data.Aeson (encode, object)
+import Data.Aeson.Types (Object, Pair, Value (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8


### PR DESCRIPTION
Some of the changes mentioned in https://github.com/freckle/megarepo/pull/35369#issuecomment-2249189218 - A few obvious ways to trim down the main module with a focus on what most modules need to emit log messages.