### PR TITLE
Accept a special value "null" for LOG_DESTINATION

### DIFF
--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        2.1.0.0
+version:        2.1.1.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Logging

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.2.0.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.1.0...main)
+
+## [v2.1.1.0](https://github.com/freckle/blammo/compare/v2.0.0.0...Blammo-v2.1.0.0)
+
+- Accept special value `null` for `LOG_DESTINATION` as a synonym for the null
+  device (`/dev/null` or `\\.\NUL` on windows).
 
 ## [v2.1.0.0](https://github.com/freckle/blammo/compare/v2.0.0.0...Blammo-v2.1.0.0)
 

--- a/Blammo/README.lhs
+++ b/Blammo/README.lhs
@@ -140,14 +140,14 @@ setting the format to `json` will automatically enable it (with
 
 ## Configuration
 
-| Setting     | Setter                      | Environment variable and format           |
-| ----------- | --------------------------- | ----------------------------------------- |
-| Format      | `setLogSettingsFormat`      | `LOG_FORMAT=tty\|json`                    |
-| Level(s)    | `setLogSettingsLevels`      | `LOG_LEVEL=<level>[,<source:level>,...]`  |
+| Setting     | Setter                      | Environment variable and format                 |
+| ----------- | --------------------------- | ----------------------------------------------- |
+| Format      | `setLogSettingsFormat`      | `LOG_FORMAT=tty\|json`                          |
+| Level(s)    | `setLogSettingsLevels`      | `LOG_LEVEL=<level>[,<source:level>,...]`        |
 | Destination | `setLogSettingsDestination` | `LOG_DESTINATION=stdout\|stderr\|null\|@<path>` |
-| Color       | `setLogSettingsColor `      | `LOG_COLOR=auto\|always\|never`           |
-| Breakpoint  | `setLogSettingsBreakpoint`  | `LOG_BREAKPOINT=<number>`                 |
-| Concurrency | `setLogSettingsConcurrency` | `LOG_CONCURRENCY=<number>`                |
+| Color       | `setLogSettingsColor `      | `LOG_COLOR=auto\|always\|never`                 |
+| Breakpoint  | `setLogSettingsBreakpoint`  | `LOG_BREAKPOINT=<number>`                       |
+| Concurrency | `setLogSettingsConcurrency` | `LOG_CONCURRENCY=<number>`                      |
 
 ## Advanced Usage
 

--- a/Blammo/README.lhs
+++ b/Blammo/README.lhs
@@ -144,7 +144,7 @@ setting the format to `json` will automatically enable it (with
 | ----------- | --------------------------- | ----------------------------------------- |
 | Format      | `setLogSettingsFormat`      | `LOG_FORMAT=tty\|json`                    |
 | Level(s)    | `setLogSettingsLevels`      | `LOG_LEVEL=<level>[,<source:level>,...]`  |
-| Destination | `setLogSettingsDestination` | `LOG_DESTINATION=stdout\|stderr\|@<path>` |
+| Destination | `setLogSettingsDestination` | `LOG_DESTINATION=stdout\|stderr\|null\|@<path>` |
 | Color       | `setLogSettingsColor `      | `LOG_COLOR=auto\|always\|never`           |
 | Breakpoint  | `setLogSettingsBreakpoint`  | `LOG_BREAKPOINT=<number>`                 |
 | Concurrency | `setLogSettingsConcurrency` | `LOG_CONCURRENCY=<number>`                |

--- a/Blammo/package.yaml
+++ b/Blammo/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 2.1.0.0
+version: 2.1.1.0
 maintainer: Freckle Education
 category: Logging
 github: freckle/blammo

--- a/Blammo/src/Blammo/Logging/LogSettings/Env.hs
+++ b/Blammo/src/Blammo/Logging/LogSettings/Env.hs
@@ -3,9 +3,9 @@
 -- - @LOG_LEVEL@: a known log level (case insensitive) and optional levels by
 --   source. See "Logging.LogSettings.LogLevels".
 --
--- - @LOG_DESTINATION@: the string @stderr@ or @stdout@ (case sensitive), or
---   @\@{path}@ to log to the file at @path@. Unrecognized values will produce
---   and error.
+-- - @LOG_DESTINATION@: the string @stderr@, @stdout@ or @null@, (case
+--   sensitive), or @\@{path}@ to log to the file at @path@. Unrecognized values
+--   will produce an error.
 --
 -- - @LOG_FORMAT@: the string @tty@ or @json@. Unrecognized values will produce
 --   an error.


### PR DESCRIPTION
This parses a new value `"null"` as a `LogDestination`. On non-Windows
systems, it'll be equivalent to `"@/dev/null"`. On Windows systems,
`"@\\.\NUL"` (an explicitly-namespaced form for the `NUL` device[^1]).

Closes #50.

I chose not to investigate the open question about whether or not
`LOG_DESTINATION=NUL` would already Just Work. I decided it didn't
matter, for two reasons:

1. While it's likely "specifying `NUL`" may conceptually work, it's very
   possible you still need to practically use `LOG_DESTINATION=\\.\NUL`
   to do it.

   That would not be very discoverable and the escaping required would
   be quite error-prone, making the `null` sugar valuable.

2. Mixed-OS teams attempting to have null as a default in (e.g.) `.env`
   can't do so today.

   Without this sugar, such teams would have to concretely pick
   `/dev/null` or `NUL`.

Together, this seemed like enough to warrant the small bit of alias
complexity.

[^1]: https://stackoverflow.com/a/58177337
