### PR TITLE
Add setLoggerReformat

### DIFF
--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        2.1.1.0
+version:        2.1.2.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Logging

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.1.0...main)
 
-## [v2.1.1.0](https://github.com/freckle/blammo/compare/v2.0.0.0...Blammo-v2.1.0.0)
+## [v2.1.1.0](https://github.com/freckle/blammo/compare/v2.1.0.0...Blammo-v2.1.1.0)
 
 - Accept special value `null` for `LOG_DESTINATION` as a synonym for the null
   device (`/dev/null` or `\\.\NUL` on windows).

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.1.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.2.0...main)
+
+## [v2.1.2.0](https://github.com/freckle/blammo/compare/v2.1.1.0...Blammo-v2.1.2.0)
+
+- Add `setLoggerReformat`
 
 ## [v2.1.1.0](https://github.com/freckle/blammo/compare/v2.1.0.0...Blammo-v2.1.1.0)
 

--- a/Blammo/package.yaml
+++ b/Blammo/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 2.1.1.0
+version: 2.1.2.0
 maintainer: Freckle Education
 category: Logging
 github: freckle/blammo

--- a/Blammo/src/Blammo/Logging/LogSettings/Env.hs
+++ b/Blammo/src/Blammo/Logging/LogSettings/Env.hs
@@ -74,7 +74,7 @@ parseWith = Env.parse id . parserWith
 
 parserWith :: LogSettings -> Parser Error LogSettings
 parserWith defaults =
-  ($ defaults) . appEndo . mconcat
+  flip (appEndo . mconcat) defaults
     <$> sequenceA
       [ endoVar readLogLevels setLogSettingsLevels "LOG_LEVEL"
       , endoVar readLogDestination setLogSettingsDestination "LOG_DESTINATION"

--- a/Blammo/tests/Blammo/Logging/TerminalSpec.hs
+++ b/Blammo/tests/Blammo/Logging/TerminalSpec.hs
@@ -7,14 +7,19 @@ module Blammo.Logging.TerminalSpec
 import Prelude
 
 import Blammo.Logging
+import Blammo.Logging.Colors (noColors)
+import Blammo.Logging.LogSettings
+  ( LogSettings
+  , defaultLogSettings
+  , setLogSettingsBreakpoint
+  )
 import Blammo.Logging.Logger (LoggedMessage (..))
 import Blammo.Logging.Terminal
-import Data.Aeson (encode, object)
+import Data.Aeson (object)
 import Data.Aeson.Types (Object, Pair, Value (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BSL
 import Data.Text (Text)
 import Data.Time
 import Test.Hspec
@@ -22,35 +27,22 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "reformatTerminal" $ do
-    it "passes-through none-LoggedMessages as-is" $ do
-      let
-        bs :: ByteString
-        bs = "I'm not even JSON"
-
-        bsJSON :: ByteString
-        bsJSON = "{\"I'm\":\"Valid JSON, but not LoggedMessage\"}"
-
-      reformatTerminal 0 False LevelInfo bs `shouldBe` bs
-      reformatTerminal 0 False LevelInfo bsJSON `shouldBe` bsJSON
-
     it "reformats LoggedMessages with complex attributes" $ do
       let
-        bs =
-          BSL.toStrict $
-            encode
-              LoggedMessage
-                { loggedMessageTimestamp =
-                    UTCTime
-                      { utctDay = fromGregorian 2022 1 1
-                      , utctDayTime = 0
-                      }
-                , loggedMessageLevel = LevelInfo
-                , loggedMessageLoc = Nothing
-                , loggedMessageLogSource = Just "app"
-                , loggedMessageThreadContext = keyMap ["x" .= object ["y" .= True]]
-                , loggedMessageText = "I'm a log message"
-                , loggedMessageMeta = keyMap ["a" .= [1 :: Int, 2, 3]]
-                }
+        lm =
+          LoggedMessage
+            { loggedMessageTimestamp =
+                UTCTime
+                  { utctDay = fromGregorian 2022 1 1
+                  , utctDayTime = 0
+                  }
+            , loggedMessageLevel = LevelInfo
+            , loggedMessageLoc = Nothing
+            , loggedMessageLogSource = Just "app"
+            , loggedMessageThreadContext = keyMap ["x" .= object ["y" .= True]]
+            , loggedMessageText = "I'm a log message"
+            , loggedMessageMeta = keyMap ["a" .= [1 :: Int, 2, 3]]
+            }
 
         expected =
           mconcat
@@ -58,32 +50,30 @@ spec = do
             , " source=app x={y: True} a=[1, 2, 3]"
             ]
 
-      reformatTerminal 120 False LevelInfo bs `shouldBe` expected
+      reformatTerminal (settings 120) noColors LevelInfo lm `shouldBe` expected
 
     it "moves attributes to multi-line at the given breakpoint" $ do
       let
-        bs =
-          BSL.toStrict $
-            encode
-              LoggedMessage
-                { loggedMessageTimestamp =
-                    UTCTime
-                      { utctDay = fromGregorian 2022 1 1
-                      , utctDayTime = 0
-                      }
-                , loggedMessageLevel = LevelInfo
-                , loggedMessageLoc = Nothing
-                , loggedMessageLogSource = Just "app"
-                , loggedMessageThreadContext = mempty
-                , loggedMessageText = "I'm a log message"
-                , loggedMessageMeta =
-                    keyMap
-                      [ "a" .= ("aaaaaaaaa" :: Text)
-                      , "b" .= ("aaaaaaaaa" :: Text)
-                      , "c" .= ("aaaaaaaaa" :: Text)
-                      , "d" .= ("aaaaaaaaa" :: Text)
-                      ]
-                }
+        lm =
+          LoggedMessage
+            { loggedMessageTimestamp =
+                UTCTime
+                  { utctDay = fromGregorian 2022 1 1
+                  , utctDayTime = 0
+                  }
+            , loggedMessageLevel = LevelInfo
+            , loggedMessageLoc = Nothing
+            , loggedMessageLogSource = Just "app"
+            , loggedMessageThreadContext = mempty
+            , loggedMessageText = "I'm a log message"
+            , loggedMessageMeta =
+                keyMap
+                  [ "a" .= ("aaaaaaaaa" :: Text)
+                  , "b" .= ("aaaaaaaaa" :: Text)
+                  , "c" .= ("aaaaaaaaa" :: Text)
+                  , "d" .= ("aaaaaaaaa" :: Text)
+                  ]
+            }
 
         single =
           mconcat
@@ -103,33 +93,32 @@ spec = do
 
         breakpoint = BS.length single
 
-      reformatTerminal breakpoint False LevelInfo bs `shouldBe` single
-      reformatTerminal (breakpoint - 1) False LevelInfo bs `shouldBe` multi
+      reformatTerminal (settings breakpoint) noColors LevelInfo lm `shouldBe` single
+      reformatTerminal (settings $ breakpoint - 1) noColors LevelInfo lm
+        `shouldBe` multi
 
   it "aligns multi-line correctly even with color escapes" $ do
     let
-      bs =
-        BSL.toStrict $
-          encode
-            LoggedMessage
-              { loggedMessageTimestamp =
-                  UTCTime
-                    { utctDay = fromGregorian 2022 1 1
-                    , utctDayTime = 0
-                    }
-              , loggedMessageLevel = LevelInfo
-              , loggedMessageLoc = Nothing
-              , loggedMessageLogSource = Just "app"
-              , loggedMessageThreadContext = mempty
-              , loggedMessageText = "I'm a log message"
-              , loggedMessageMeta =
-                  keyMap
-                    [ "a" .= ("aaaaaaaaa" :: Text)
-                    , "b" .= ("aaaaaaaaa" :: Text)
-                    , "c" .= ("aaaaaaaaa" :: Text)
-                    , "d" .= ("aaaaaaaaa" :: Text)
-                    ]
-              }
+      lm =
+        LoggedMessage
+          { loggedMessageTimestamp =
+              UTCTime
+                { utctDay = fromGregorian 2022 1 1
+                , utctDayTime = 0
+                }
+          , loggedMessageLevel = LevelInfo
+          , loggedMessageLoc = Nothing
+          , loggedMessageLogSource = Just "app"
+          , loggedMessageThreadContext = mempty
+          , loggedMessageText = "I'm a log message"
+          , loggedMessageMeta =
+              keyMap
+                [ "a" .= ("aaaaaaaaa" :: Text)
+                , "b" .= ("aaaaaaaaa" :: Text)
+                , "c" .= ("aaaaaaaaa" :: Text)
+                , "d" .= ("aaaaaaaaa" :: Text)
+                ]
+          }
 
       expected =
         mconcat
@@ -141,7 +130,11 @@ spec = do
           , "                                d=aaaaaaaaa"
           ]
 
-    stripColor (reformatTerminal 120 True LevelInfo bs) `shouldBe` expected
+    stripColor (reformatTerminal (settings 120) noColors LevelInfo lm)
+      `shouldBe` expected
+
+settings :: Int -> LogSettings
+settings breakpoint = setLogSettingsBreakpoint breakpoint defaultLogSettings
 
 keyMap :: [Pair] -> Object
 keyMap ps = km where Object km = object ps


### PR DESCRIPTION
This refactors the contract between `reformatTerminal` and the
construction that happens in `newLogger`.

Previously, we constructed `lReformat` directly, which is a function of
only `LogLevel` and `ByteString`. This meant that a "reformat" function
such as `reformatTerminal` had to do some extra work that all such
functions would have to do:

- Construct the `Colors` value if needed
- Return that `ByteString` as-is if it doesn't parse as `LoggedMessage`

We can pull both of these responsibilities out into `newLogger` itself
and simplify `reformatTerminal` by giving it what it needs directly.

Also, by passing `LogSettings` entirely (instead of just the
breakpoint), we've now made its signature into something that works well
as a generic "reformat" interface.

Then, by putting that logic behind a `setLoggerReformat` that
`newLogger` uses internally, we give users a hook for assign any such
"reformat" function from the outside too:

```hs
main :: IO ()
main = do
  withLoggerEnv $ \logger -> do
    let app = App $ setLoggerReformat myReformat logger
    runAppM app -- ...

myReformat :: LogSettings -> Colors -> LogLevel -> LoggedMessage -> ByteString
myReformat = undefined
```

An extension like this doesn't interact with `LOG_FORMAT`, which may be
surprising, but it works well for situations that don't need to be
runtime-dynamic like that, such as CLIs.
