### PR TITLE
Spaces around "=" in terminal output

### DIFF
--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        2.1.2.0
+version:        2.1.3.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Logging

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.2.0...main)
+## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.3.0...main)
+
+## [v2.1.3.0](https://github.com/freckle/blammo/compare/v2.1.2.0...Blammo-v2.1.3.0)
+
+- [#67](https://github.com/freckle/blammo/pull/67) - Adds spaces around the `=`
+  character that separates metadata keys from values in the TTY formatter.
 
 ## [v2.1.2.0](https://github.com/freckle/blammo/compare/v2.1.1.0...Blammo-v2.1.2.0)
 

--- a/Blammo/package.yaml
+++ b/Blammo/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 2.1.2.0
+version: 2.1.3.0
 maintainer: Freckle Education
 category: Logging
 github: freckle/blammo

--- a/Blammo/src/Blammo/Logging/Terminal.hs
+++ b/Blammo/src/Blammo/Logging/Terminal.hs
@@ -94,7 +94,7 @@ colorizeKeyMap sep Colors {..} km
   | otherwise = foldMap (uncurry fromPair) $ sortOn fst $ KeyMap.toList km
  where
   fromPair k v =
-    sep <> logPiece cyan (Key.toText k) <> "=" <> logPiece magenta (fromValue v)
+    sep <> logPiece cyan (Key.toText k) <> " = " <> logPiece magenta (fromValue v)
 
   fromValue = \case
     Object m -> obj $ map (uncurry renderPairNested) $ KeyMap.toList m


### PR DESCRIPTION
This has been bugging me for a while.

Examples:

- `total non-deprecated, printable=3`
  changes to
  `total non-deprecated, printable = 3`
  which conveys the associativity better rather than making it look like "printable=3" is a single word

- `file=math/questions/basic/8.EE.6-1.1.csv`
  changes to
  `file = math/questions/basic/8.EE.6-1.1.csv`
  which makes the file name clickable, letting me alt+click to jump to the source in vscode