### PR TITLE
Version bump

### DIFF
--- a/Blammo/Blammo.cabal
+++ b/Blammo/Blammo.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           Blammo
-version:        2.1.3.0
+version:        2.1.4.0
 synopsis:       Batteries-included Structured Logging library
 description:    Please see README.md
 category:       Logging

--- a/Blammo/CHANGELOG.md
+++ b/Blammo/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/blammo/compare/Blammo-v2.1.3.0...main)
 
+## [v2.1.4.0](https://github.com/freckle/blammo/compare/v2.1.3.0...Blammo-v2.1.4.0)
+
+- Add `logTrace` and `logTraceNS` functions
+
 ## [v2.1.3.0](https://github.com/freckle/blammo/compare/v2.1.2.0...Blammo-v2.1.3.0)
 
 - Add `setLogSettingsColors` to support customizing colors

--- a/Blammo/package.yaml
+++ b/Blammo/package.yaml
@@ -1,5 +1,5 @@
 name: Blammo
-version: 2.1.3.0
+version: 2.1.4.0
 maintainer: Freckle Education
 category: Logging
 github: freckle/blammo

--- a/Blammo/src/Blammo/Logging.hs
+++ b/Blammo/src/Blammo/Logging.hs
@@ -18,6 +18,7 @@ module Blammo.Logging
     -- | Import "Control.Monad.Logger.Aeson" if you want more
 
     -- *** Implicit call stack, no 'LogSource'
+  , logTrace
   , logDebug
   , logInfo
   , logWarn
@@ -26,6 +27,7 @@ module Blammo.Logging
 
     -- *** Implicit call stack, with 'LogSource'
   , LogSource
+  , logTraceNS
   , logDebugNS
   , logInfoNS
   , logWarnNS
@@ -33,6 +35,14 @@ module Blammo.Logging
   , logOtherNS
   ) where
 
+import Prelude
+
 import Blammo.Logging.Logger
 import Control.Monad.Logger.Aeson
 import Data.Aeson (Series)
+
+logTrace :: MonadLogger m => Message -> m ()
+logTrace = logOther $ LevelOther "trace"
+
+logTraceNS :: MonadLogger m => LogSource -> Message -> m ()
+logTraceNS s = logOtherNS s $ LevelOther "trace"


### PR DESCRIPTION
### Add logTrace functions

2e8ab4429b91d914826d091854adc8f17bb6fd1d

These are named functions logging with `LevelOther "trace"`, which is a
log-level used by many libraries as a level more verbose than `debug`,
for example Amazonka.

We already have special support for `trace` when filtering by
log-levels, to ensure that trace messages are considered "less than"
debug, so silencing works as expected. By default, "other" log levels
are considered "greater than" all non-other levels, so without this
trace messages would appear even at `LOG_LEVEL=error`.

Given that, it seems reasonable to consider it a 1st-class notion in
Blammo, and include `logTrace` functions too.

Closes #48.

### Version bump

3d23416574ce120ab7e6c2766f6d4d9252077ea7
