### PR TITLE
ci: add alls-green check job gating test and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,14 @@ jobs:
         with:
           fail-on: warning
           path: '["Blammo/src/", "Blammo/tests/", "Blammo-wai/src/"]'
+
+  check:
+    if: always()
+    needs:
+      - test
+      - lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Adds the `check` aggregator job from `haskell-library-template`, gating on both `test` and `lint`.

Today this repo's ruleset requires 6 per-resolver `test (...)` contexts and nothing for `lint`, so
HLint runs on every PR at `fail-on: warning`, reports its result, and cannot block a merge. 37 of 43
haskell-package repos have that gap.

Once this merges and the context reports, the ruleset collapses to a single `- context: check` in
`github-vending-machine`. That gates lint and removes the per-resolver list, so adding or dropping a
`stack-*.yaml` rung stops needing a matching GVM PR — the same move
freckle/github-vending-machine#263 made for the template itself.

Nothing changes about what runs. `test`'s matrix already includes every leg the ruleset requires today,
nightly among them, so the aggregator is behaviour-preserving here. Repos where nightly runs but is
*not* currently required are deliberately excluded from this port: `alls-green`'s `allowed-failures`
matches job names, and a matrix is one entry, so nightly cannot be exempted individually there.

**This repo's CI last ran on 2026-08-20.** GitHub evicts Actions caches after 7 days, so expect the
first run here to be a cold rebuild, and expect it to possibly fail while populating the Stack package
index. That happened on freckle/graphula#118 and cleared on a re-run of the failed jobs. Re-run before
reading a red result as a real breakage.

The manifest change is deliberately *not* in this PR — a required context that no job produces behaves
like a deadlock, so the job has to land first.
